### PR TITLE
local resolvers sources

### DIFF
--- a/dnscrypt-proxy/dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/dnscrypt-proxy.toml
@@ -249,6 +249,13 @@ format = 'tsv'
   refresh_delay = 168
   prefix = ''
 
+  #[sources.'local proxy v1 list']
+  #url = '/some/local/path/to/dnscrypt-resolvers.csv'
+  #minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+  #cache_file = 'never-used-fake-cache.csv'
+  #format = 'v1'
+  #refresh_delay = 168
+  #prefix = ''
 
 ## Local, static list of available servers
 

--- a/dnscrypt-proxy/sources.go
+++ b/dnscrypt-proxy/sources.go
@@ -64,6 +64,22 @@ func fetchWithCache(url string, cacheFile string) (in string, cached bool, delay
 		cached = true
 		return
 	}
+
+	_, err = os.Stat(url)
+	if err == nil {
+		var bin []byte
+		bin, err = ioutil.ReadFile(url)
+		if err != nil {
+			err = errors.New("Unable to read source file")
+			return
+		}
+		in = string(bin)
+		cached = true //prevent caching & minisign checks
+		return
+	} else {
+		err = nil
+	}
+
 	var resp *http.Response
 	dlog.Infof("Loading source information from URL [%s]", url)
 	resp, err = http.Get(url)


### PR DESCRIPTION
Support for local resolvers list managed by external tools. cache_file and valid minisign_key settings are required (validations @ config.go) but not used. IMHO should be ok for beta.