### PR TITLE
Fix systemd socket support

### DIFF
--- a/dnscrypt-proxy/systemd_linux.go
+++ b/dnscrypt-proxy/systemd_linux.go
@@ -9,18 +9,22 @@ import (
 )
 
 func (proxy *Proxy) SystemDListeners() error {
-	listeners, err := activation.Listeners(true)
-	if err != nil && len(listeners) > 0 {
+	listeners, err := activation.Listeners(false)
+	if err == nil && len(listeners) > 0 {
 		for i, listener := range listeners {
-			dlog.Noticef("Wiring systemd TCP socket #%d", i)
-			proxy.tcpListener(listener.(*net.TCPListener))
+			if listener != nil {
+				dlog.Noticef("Wiring systemd TCP socket #%d", i)
+				go proxy.tcpListener(listener.(*net.TCPListener))
+			}
 		}
 	}
-	packetConns, err := activation.PacketConns(true)
-	if err != nil && len(packetConns) > 0 {
+	packetConns, err := activation.PacketConns(false)
+	if err == nil && len(packetConns) > 0 {
 		for i, packetConn := range packetConns {
-			dlog.Noticef("Wiring systemd UDP socket #%d", i)
-			proxy.udpListener(packetConn.(*net.UDPConn))
+			if packetConn != nil {
+				dlog.Noticef("Wiring systemd UDP socket #%d", i)
+				go proxy.udpListener(packetConn.(*net.UDPConn))
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
I have fixed some parts that caused this feature to not be functional. With these changes I can confirm dnscrypt-proxy with systemd sockets works on my machine.

I have changed `activation.Listeners(true)` to `activation.Listeners(false)` because otherwise the environment variables passed by systemd to the service are blanked and then the UDP sockets can not be detected afterwards. Also, listeners need to be checked to not be `nil` in order to not pass it to the listener functions, since doing so causes an error.