### PR TITLE
Update systemd service to pull nss-lookup.target in.

### DIFF
--- a/systemd/dnscrypt-proxy.service
+++ b/systemd/dnscrypt-proxy.service
@@ -4,6 +4,7 @@ Documentation=man:dnscrypt-proxy(8)
 Requires=dnscrypt-proxy.socket
 After=network.target
 Before=nss-lookup.target
+Wants=nss-lookup.target
 
 [Install]
 Also=dnscrypt-proxy.socket


### PR DESCRIPTION
According to [`systemd.special(7)`](https://www.freedesktop.org/software/systemd/man/systemd.special.html), nss-lookup.target is a Special Passive System Unit. This means that services depending on its functionality should order themselves after the target with an After= type dependency, but should not have a Wants= dependency for them. Therefore, nss-lookup.target should be pulled in by the providing services instead, or the consumer services will never be able to order themselves after the providing services since nss-lookup.target would not be pulled in at any point in the boot process. dnscrypt-proxy.service provides name lookup functionality, and has a Before= dependency on nss-lookup.target. However, it should have a Wants= dependency on it as well in order to indicate readiness of name lookup functionality.