### PR TITLE
Cache Plugin: return non-fixed TTL for cached entries

### DIFF
--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -85,22 +85,33 @@ func getMinTTL(msg *dns.Msg, minTTL uint32, maxTTL uint32, negCacheMinTTL uint32
 
 func setMaxTTL(msg *dns.Msg, ttl uint32, force bool) {
 	for _, rr := range msg.Answer {
-		if (ttl < rr.Header().Ttl) || force {
+		if ttl < rr.Header().Ttl {
 			rr.Header().Ttl = ttl
 		}
 	}
 	for _, rr := range msg.Ns {
-    if (ttl < rr.Header().Ttl) || force {
+	  if ttl < rr.Header().Ttl {
 			rr.Header().Ttl = ttl
 		}
 	}
 	for _, rr := range msg.Extra {
-    if (ttl < rr.Header().Ttl) || force {
+	  if ttl < rr.Header().Ttl {
 			rr.Header().Ttl = ttl
 		}
 	}
 }
 
 func updateTTL(msg *dns.Msg, expiration time.Time) {
-  setMaxTTL(msg, uint32(time.Until(expiration) / time.Second), true)
+
+	ttl := uint32(time.Until(expiration) / time.Second)
+
+	for _, rr := range msg.Answer {
+	    rr.Header().Ttl = ttl
+	}
+	for _, rr := range msg.Ns {
+	    rr.Header().Ttl = ttl
+	}
+	for _, rr := range msg.Extra {
+	    rr.Header().Ttl = ttl
+	}
 }

--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -83,7 +83,7 @@ func getMinTTL(msg *dns.Msg, minTTL uint32, maxTTL uint32, negCacheMinTTL uint32
 	return time.Duration(ttl) * time.Second
 }
 
-func setMaxTTL(msg *dns.Msg, ttl uint32, force bool) {
+func setMaxTTL(msg *dns.Msg, ttl uint32) {
 	for _, rr := range msg.Answer {
 		if ttl < rr.Header().Ttl {
 			rr.Header().Ttl = ttl

--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -83,20 +83,24 @@ func getMinTTL(msg *dns.Msg, minTTL uint32, maxTTL uint32, negCacheMinTTL uint32
 	return time.Duration(ttl) * time.Second
 }
 
-func setMaxTTL(msg *dns.Msg, ttl uint32) {
+func setMaxTTL(msg *dns.Msg, ttl uint32, force bool) {
 	for _, rr := range msg.Answer {
-		if ttl < rr.Header().Ttl {
+		if (ttl < rr.Header().Ttl) || force {
 			rr.Header().Ttl = ttl
 		}
 	}
 	for _, rr := range msg.Ns {
-		if ttl < rr.Header().Ttl {
+    if (ttl < rr.Header().Ttl) || force {
 			rr.Header().Ttl = ttl
 		}
 	}
 	for _, rr := range msg.Extra {
-		if ttl < rr.Header().Ttl {
+    if (ttl < rr.Header().Ttl) || force {
 			rr.Header().Ttl = ttl
 		}
 	}
+}
+
+func updateTTL(msg *dns.Msg, expiration time.Time) {
+  setMaxTTL(msg, uint32(time.Until(expiration) / time.Second), true)
 }

--- a/dnscrypt-proxy/plugin_cache.go
+++ b/dnscrypt-proxy/plugin_cache.go
@@ -70,6 +70,8 @@ func (plugin *PluginCacheResponse) Eval(pluginsState *PluginsState, msg *dns.Msg
 		}
 	}
 	plugin.cachedResponses.cache.Add(cacheKey, cachedResponse)
+
+  updateTTL(msg, cachedResponse.expiration)
 	return nil
 }
 
@@ -117,6 +119,9 @@ func (plugin *PluginCache) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 	if time.Now().After(cached.expiration) {
 		return nil
 	}
+
+  updateTTL(&cached.msg, cached.expiration)
+
 	synth := cached.msg
 	synth.Id = msg.Id
 	synth.Response = true

--- a/dnscrypt-proxy/plugin_cache.go
+++ b/dnscrypt-proxy/plugin_cache.go
@@ -71,7 +71,7 @@ func (plugin *PluginCacheResponse) Eval(pluginsState *PluginsState, msg *dns.Msg
 	}
 	plugin.cachedResponses.cache.Add(cacheKey, cachedResponse)
 
-  updateTTL(msg, cachedResponse.expiration)
+	updateTTL(msg, cachedResponse.expiration)
 	return nil
 }
 
@@ -120,7 +120,7 @@ func (plugin *PluginCache) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 		return nil
 	}
 
-  updateTTL(&cached.msg, cached.expiration)
+	updateTTL(&cached.msg, cached.expiration)
 
 	synth := cached.msg
 	synth.Id = msg.Id

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -178,7 +178,7 @@ func (pluginsState *PluginsState) ApplyResponsePlugins(pluginsGlobals *PluginsGl
 	}
 	pluginsGlobals.RUnlock()
 	if ttl != nil {
-		setMaxTTL(&msg, *ttl, false)
+		setMaxTTL(&msg, *ttl)
 	}
 	packet2, err := msg.PackBuffer(packet)
 	if err != nil {

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -178,7 +178,7 @@ func (pluginsState *PluginsState) ApplyResponsePlugins(pluginsGlobals *PluginsGl
 	}
 	pluginsGlobals.RUnlock()
 	if ttl != nil {
-		setMaxTTL(&msg, *ttl)
+		setMaxTTL(&msg, *ttl, false)
 	}
 	packet2, err := msg.PackBuffer(packet)
 	if err != nil {


### PR DESCRIPTION
Using the cache plugin today I noticed an error with how TTLs are returned.

for example with this configuration:
```
cache = true
cache_min_ttl = 300
cache_max_ttl = 7200
```

and this command:
``dig github.com A``

github.com A record TTL is dynamic (between 5-100) so the expected TTL to be returned by dnscrypt-proxy is 300. However, the original value is returned instead making clients issuing additional queries (although they are returned from cache and not being sent out again to upstream)
This is more of a issue when dnscrypt-proxy is not being used as local resolver.

Also, dnsmasq TTL values are relative to the time it hit the cache for the first time:
``dig google.com A`` returns TTL of 130, if I will query dnsmasq for a second time after 30 seconds the result is 100

```
; <<>> DiG 9.11.2-P1 <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 52449
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1204
;; QUESTION SECTION:
;google.com.                    IN      A

;; ANSWER SECTION:
google.com.             130     IN      A       172.217.23.14
....
;; WHEN: Fri Feb 09 19:45:23 UTC 2018
```


```
; <<>> DiG 9.11.2-P1 <<>> google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 52449
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1204
;; QUESTION SECTION:
;google.com.                    IN      A

;; ANSWER SECTION:
google.com.             100     IN      A       172.217.23.14
....
;; WHEN: Fri Feb 09 19:45:53 UTC 2018
```

I'm not sure if this behaviour is actually defined in the RFC, but I think it's a good choice.
This patch is fixing both.