### PR TITLE
Handle time-based blacklist in generate-domains-blacklist.py

### DIFF
--- a/utils/generate-domains-blacklists/domains-time-restricted.txt
+++ b/utils/generate-domains-blacklists/domains-time-restricted.txt
@@ -1,0 +1,4 @@
+## Time schedules in dnscrypt-proxy.toml
+# twitter.com @work
+# facebook.com @work
+# *.youtube.*  @time-to-sleep


### PR DESCRIPTION
* Read time-based blacklist from domains-time-restricted.txt by default ; domains in this file are considered whitelisted (from other blacklists)
* Modified `list_from_url` to `load_from_url` to avoid reading the `time_restricted` file twice (1 for output, 1 for whitelist)
* Create `domains-time-restricted.txt` with commented examples