### PR TITLE
chore: build freebsd armv7 binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,13 @@ script:
   - tar czpvf dnscrypt-proxy-freebsd_amd64-${TRAVIS_TAG:-dev}.tar.gz freebsd-amd64
 
   - go clean
+  - env GOOS=freebsd GOARCH=arm GOARM=7 go build -ldflags="-s -w"
+  - mkdir freebsd-armv7
+  - ln dnscrypt-proxy freebsd-armv7/
+  - ln ../LICENSE example-dnscrypt-proxy.toml example-*.txt freebsd-armv7/
+  - tar czpvf dnscrypt-proxy-freebsd_armv7-${TRAVIS_TAG:-dev}.tar.gz freebsd-armv7
+
+  - go clean
   - env GOOS=dragonfly GOARCH=amd64 go build -ldflags="-s -w"
   - mkdir dragonflybsd-amd64
   - ln dnscrypt-proxy dragonflybsd-amd64/


### PR DESCRIPTION
Hi !

I would love to run `dnscrypt-proxy` on my Pfsense [Netgate SG-1000](https://www.netgate.com/solutions/pfsense/sg-1000.html) micro-firewall but no release is currently available for this hardware at the moment.

```
[2.4.2-RELEASE][admin@router.bds.home]/tmp: uname -a
FreeBSD router.bds.home 11.1-RELEASE-p6 FreeBSD 11.1-RELEASE-p6 #0 r313908+a5b33c9d1c4(RELENG_2_4): Tue Dec 12 15:08:51 CST 2017     root@buildbot2.netgate.com:/xbuilder/crossbuild-242/work/obj-ufw-armv6/arm.armv6/xbuilder/crossbuild-242/pfSense/tmp/FreeBSD-src/sys/pfSense-uFW  arm
```

Here's is a PR to build a FreedBSD armv7 binary. I can also add a commit for armv6 if you want.

Thank you in advance.

nb: I'm not sure if I correctly named the directory.