### PR TITLE
Let default systemd socket listen on both IPv4 and IPv6

### DIFF
--- a/systemd/dnscrypt-proxy.socket
+++ b/systemd/dnscrypt-proxy.socket
@@ -2,8 +2,10 @@
 Description=dnscrypt-proxy listening socket
 
 [Socket]
-ListenStream=53
-ListenDatagram=53
+ListenStream=127.0.0.1:53
+ListenStream=[::1]:53
+ListenDatagram=127.0.0.1:53
+ListenDatagram=[::1]:53
 NoDelay=true
 DeferAcceptSec=1
 

--- a/systemd/dnscrypt-proxy.socket
+++ b/systemd/dnscrypt-proxy.socket
@@ -2,8 +2,8 @@
 Description=dnscrypt-proxy listening socket
 
 [Socket]
-ListenStream=127.0.0.1:53
-ListenDatagram=127.0.0.1:53
+ListenStream=53
+ListenDatagram=53
 NoDelay=true
 DeferAcceptSec=1
 


### PR DESCRIPTION
Setting listen_addresses = [] in config will listen on systemd socket, but by previous systemd socket config it would only listen on IPv4 127.0.0.1:53 without IPv6. This change fixes it.