### PR TITLE
Adding DynamicUser to systemd service file, enhancing socket and service

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -26,7 +26,7 @@
 
 
 ## List of local addresses and ports to listen to. Can be IPv4 and/or IPv6.
-## To only use systemd activation sockets, use an empty set: []
+## Note: When using systemd socket activation, choose an empty set (i.e. [] ).
 
 listen_addresses = ['127.0.0.1:53', '[::1]:53']
 

--- a/systemd/dnscrypt-proxy.service
+++ b/systemd/dnscrypt-proxy.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=DNSCrypt client proxy
+Description=DNSCrypt-proxy client
 Documentation=https://github.com/jedisct1/dnscrypt-proxy/wiki
 After=network.target
 Before=nss-lookup.target
@@ -7,15 +7,20 @@ Wants=nss-lookup.target
 
 [Service]
 NonBlocking=true
+ExecStart=/usr/bin/dnscrypt-proxy --config /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+ProtectHome=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Run dnscrypt-proxy as unprivileged user with
+# temporary assigned UID/GID. See man:systemd.exec
+# for more info. Requires systemd 232+.
 DynamicUser=yes
 CacheDirectory=dnscrypt-proxy
 LogsDirectory=dnscrypt-proxy
 RuntimeDirectory=dnscrypt-proxy
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_BIND_SERVICE
-ExecStart=/usr/bin/dnscrypt-proxy --config /etc/dnscrypt-proxy/dnscrypt-proxy.toml
-ProtectControlGroups=yes
-ProtectKernelModules=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/dnscrypt-proxy.service
+++ b/systemd/dnscrypt-proxy.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=DNSCrypt-proxy client
 Documentation=https://github.com/jedisct1/dnscrypt-proxy/wiki
+Requires=dnscrypt-proxy.socket
 After=network.target
 Before=nss-lookup.target
 Wants=nss-lookup.target
@@ -11,8 +12,6 @@ ExecStart=/usr/bin/dnscrypt-proxy --config /etc/dnscrypt-proxy/dnscrypt-proxy.to
 ProtectHome=yes
 ProtectControlGroups=yes
 ProtectKernelModules=yes
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 # Run dnscrypt-proxy as unprivileged user with
 # temporary assigned UID/GID. See man:systemd.exec
@@ -23,4 +22,5 @@ LogsDirectory=dnscrypt-proxy
 RuntimeDirectory=dnscrypt-proxy
 
 [Install]
+Also=dnscrypt-proxy.socket
 WantedBy=multi-user.target

--- a/systemd/dnscrypt-proxy.service
+++ b/systemd/dnscrypt-proxy.service
@@ -1,27 +1,21 @@
 [Unit]
 Description=DNSCrypt client proxy
-Documentation=man:dnscrypt-proxy(8)
-Requires=dnscrypt-proxy.socket
+Documentation=https://github.com/jedisct1/dnscrypt-proxy/wiki
 After=network.target
 Before=nss-lookup.target
 Wants=nss-lookup.target
 
-[Install]
-Also=dnscrypt-proxy.socket
-WantedBy=multi-user.target
-
 [Service]
-Type=simple
 NonBlocking=true
-ProtectHome=true
+DynamicUser=yes
+CacheDirectory=dnscrypt-proxy
+LogsDirectory=dnscrypt-proxy
+RuntimeDirectory=dnscrypt-proxy
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+ExecStart=/usr/bin/dnscrypt-proxy --config /etc/dnscrypt-proxy/dnscrypt-proxy.toml
+ProtectControlGroups=yes
+ProtectKernelModules=yes
 
-# Change this
-ExecStart=/opt/dnscrypt-proxy/dnscrypt-proxy
-
-# Run dnscrypt-proxy as unprivileged user with
-# temporary assigned UID/GID. See man:systemd.exec
-# for more info. Requires systemd 232+.
-#DynamicUser=yes
-#CacheDirectory=dnscrypt-proxy
-#LogsDirectory=dnscrypt-proxy
-#RuntimeDirectory=dnscrypt-proxy
+[Install]
+WantedBy=multi-user.target

--- a/systemd/dnscrypt-proxy.socket
+++ b/systemd/dnscrypt-proxy.socket
@@ -1,5 +1,5 @@
 [Unit]
-Description=dnscrypt-proxy listening socket
+Description=DNSCrypt-proxy socket
 Documentation=https://github.com/jedisct1/dnscrypt-proxy/wiki
 Before=nss-lookup.target
 Wants=nss-lookup.target

--- a/systemd/dnscrypt-proxy.socket
+++ b/systemd/dnscrypt-proxy.socket
@@ -1,13 +1,12 @@
 [Unit]
 Description=dnscrypt-proxy listening socket
+Documentation=https://github.com/jedisct1/dnscrypt-proxy/wiki
 Before=nss-lookup.target
 Wants=nss-lookup.target
 
 [Socket]
 ListenStream=127.0.0.1:53
-ListenStream=[::1]:53
 ListenDatagram=127.0.0.1:53
-ListenDatagram=[::1]:53
 NoDelay=true
 DeferAcceptSec=1
 

--- a/systemd/dnscrypt-proxy.socket
+++ b/systemd/dnscrypt-proxy.socket
@@ -6,7 +6,9 @@ Wants=nss-lookup.target
 
 [Socket]
 ListenStream=127.0.0.1:53
+ListenStream=[::1]:53
 ListenDatagram=127.0.0.1:53
+ListenDatagram=[::1]:53
 NoDelay=true
 DeferAcceptSec=1
 


### PR DESCRIPTION
Adding nss-lookup.target to the socket Before and Wants directive. Adding current upstream wiki as documentation to service and socket file.

Adding DynamicUser=yes to the service file, alongside various hardening settings (Protect{ControlGroups,KernelModules}. Allowing the service to bind to ports below 1024 by setting CAP_NET_BIND_SERVICE. Adding {Cache,Logs,Runtime}Directory for dnscrypt-proxy. Removing (default) Type=simple. Adding a more default ExecStart location and usage of configuration.

This is in accordance with #239 and with a little more inspiration taken from the [downstream AUR package](https://aur.archlinux.org/packages/dnscrypt-proxy-go/).

Note: I have removed the explicit `Requires` and `Also` directives from the service, as enabling and starting a socket of the same name should be enough.

Using `DynamicUser=yes` prevents the need for packagers of this software to explicitely create a user for this service (which should not be needed).