### PR TITLE
Add support print ip addr of server

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -124,6 +124,7 @@ type ServerSummary struct {
 	Name        string `json:"name"`
 	Proto       string `json:"proto"`
 	IPv6        bool   `json:"ipv6"`
+	Addr        string `json:"addr"`
 	Ports       []int  `json:"ports"`
 	DNSSEC      bool   `json:"dnssec"`
 	NoLog       bool   `json:"nolog"`
@@ -320,6 +321,7 @@ func (config *Config) printRegisteredServers(proxy *Proxy, jsonOutput bool) {
 			Name:        registeredServer.name,
 			Proto:       registeredServer.stamp.proto.String(),
 			IPv6:        strings.HasPrefix(addrStr, "["),
+			Addr:        registeredServer.stamp.serverAddrStr,
 			Ports:       []int{port},
 			DNSSEC:      registeredServer.stamp.props&ServerInformalPropertyDNSSEC != 0,
 			NoLog:       registeredServer.stamp.props&ServerInformalPropertyNoLog != 0,


### PR DESCRIPTION
Because `-list -json` doesnot print ip addr, this commit to add it.
But the ip will contain port number.

Signed-off-by: Severus <huynhok.uit@gmail.com>