### PR TITLE
minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ![dnscrypt-proxy 2](https://raw.github.com/jedisct1/dnscrypt-proxy/master/logo.png?2)
 
-A flexible DNS proxy, with support for modern encrypted DNS protocols such as [DNSCrypt v2](https://dnscrypt.info/protocol) and [DNS-over-HTTP/2](https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-03).
+A flexible DNS proxy, with support for modern encrypted DNS protocols such as [DNSCrypt v2](https://dnscrypt.info/protocol) and [DNS-over-HTTP](https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-05).
 
 ## [dnscrypt-proxy 2.0.8 final is available for download!](https://github.com/jedisct1/dnscrypt-proxy/releases/latest)
 


### PR DESCRIPTION
updated IETF draft link to version 5, updated the "official name" of the proposed protocol, which is indeed "DNS over HTTP" without S or 2.