### PR TITLE
chore: use malwaredomainlist hosts.txt file instead of CSV

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -40,7 +40,7 @@ https://mirror1.malwaredomains.com/files/justdomains
 https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt
 
 # Malware Domain List
-http://www.malwaredomainlist.com/mdlcsv.php?inactive=off
+https://www.malwaredomainlist.com/hostslist/hosts.txt
 
 # Adblock Warning Removal List
 https://easylist-downloads.adblockplus.org/antiadblockfilters.txt


### PR DESCRIPTION
Hello,

The CSV download URL of "Malwaredomainlist" (http://www.malwaredomainlist.com/mdlcsv.php?inactive=off) is often in timeout when we try to generate the dnscrypt-proxy blacklist.

"Malwaredomainlist" also provide an URL to download a pre-generated hosts.txt file which seem to be more resilient and fast.

See also:

* https://www.malwaredomainlist.com/forums/index.php?topic=3270.0
* https://www.malwaredomainlist.com/hostslist/hosts.txt
* http://www.malwaredomainlist.com/mdlcsv.php?inactive=off

Thank you.