### PR TITLE
Wait for network connectivity under systemd

### DIFF
--- a/systemd/dnscrypt-proxy.service
+++ b/systemd/dnscrypt-proxy.service
@@ -2,7 +2,7 @@
 Description=DNSCrypt-proxy client
 Documentation=https://github.com/jedisct1/dnscrypt-proxy/wiki
 Requires=dnscrypt-proxy.socket
-After=network.target
+After=network-online.target
 Before=nss-lookup.target
 Wants=nss-lookup.target
 


### PR DESCRIPTION
Currently the proxy is started with systemd before the network is ready to make DNS requests. This can cause issue with the proxy not resolving any requests well after the network coming up. This alteration addresses that in a rudimentary way.

Fixes #295