### PR TITLE
Config: Add option to specify count of fastest servers to pick from.

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	CertIgnoreTimestamp      bool   `toml:"cert_ignore_timestamp"`
 	EphemeralKeys            bool   `toml:"dnscrypt_ephemeral_keys"`
 	LBStrategy               string `toml:"lb_strategy"`
+	LBStrategyFastestCount   int    `toml:"lb_strategy_fastest_count"`
 	BlockIPv6                bool   `toml:"block_ipv6"`
 	Cache                    bool
 	CacheSize                int                        `toml:"cache_size"`
@@ -81,6 +82,7 @@ func newConfig() Config {
 		CertRefreshDelay:         240,
 		CertIgnoreTimestamp:      false,
 		EphemeralKeys:            false,
+		LBStrategyFastestCount:   DefaultLBStrategyFastestCount,
 		Cache:                    true,
 		CacheSize:                512,
 		CacheNegTTL:              0,
@@ -287,18 +289,19 @@ func ConfigLoad(proxy *Proxy, svcFlag *string) error {
 	switch strings.ToLower(config.LBStrategy) {
 	case "":
 		// default
-	case "p2":
-		lbStrategy = LBStrategyP2
-	case "ph":
-		lbStrategy = LBStrategyPH
 	case "fastest":
 		lbStrategy = LBStrategyFastest
 	case "random":
 		lbStrategy = LBStrategyRandom
+	case "ph":
+		lbStrategy = LBStrategyPH
 	default:
 		dlog.Warnf("Unknown load balancing strategy: [%s]", config.LBStrategy)
 	}
 	proxy.serversInfo.lbStrategy = lbStrategy
+	if config.LBStrategyFastestCount > 0 {
+		proxy.serversInfo.lbStrategyFastestCount = config.LBStrategyFastestCount
+	}
 
 	proxy.listenAddresses = config.ListenAddresses
 	proxy.daemonize = config.Daemonize

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -101,9 +101,11 @@ timeout = 2500
 keepalive = 30
 
 
-## Load-balancing strategy: 'p2' (default), 'ph', 'fastest' or 'random'
+## Load-balancing strategy: 
+## 'fastest' (default, picks 'lb_strategy_fastest_count' fastest servers), 'ph' (fastest half) or 'random'
 
-# lb_strategy = 'p2'
+# lb_strategy = 'fastest'
+# lb_strategy_fastest_count = 2
 
 
 ## Log level (0-6, default: 2 - 0 is very verbose, 6 only contains fatal errors)

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -438,6 +438,6 @@ func (proxy *Proxy) processIncomingQuery(serverInfo *ServerInfo, clientProto str
 
 func NewProxy() Proxy {
 	return Proxy{
-		serversInfo: ServersInfo{lbStrategy: DefaultLBStrategy},
+		serversInfo: ServersInfo{lbStrategy: DefaultLBStrategy, lbStrategyFastestCount: DefaultLBStrategyFastestCount},
 	}
 }

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -59,7 +59,7 @@ const (
 	LBStrategyPH
 )
 
-const DefaultLBStrategy = LBStrategyRandom
+const DefaultLBStrategy = LBStrategyFastest
 const DefaultLBStrategyFastestCount = 2
 
 type ServersInfo struct {


### PR DESCRIPTION
Removes LBStrategyP2 and adds a new config option 'lb_strategy_fastest_count'. When used in conjunction with 'lb_strategy=fastest' allows to pick the count of fastest servers to use.