### PR TITLE
Minor improvements for the user_name option

### DIFF
--- a/dnscrypt-proxy/main.go
+++ b/dnscrypt-proxy/main.go
@@ -98,8 +98,8 @@ func (app *App) Start(service service.Service) error {
 }
 
 func (app *App) AppMain(proxy *Proxy) {
-	proxy.StartProxy()
 	pidfile.Write()
+	proxy.StartProxy()
 	<-app.quit
 	dlog.Notice("Quit signal received...")
 	app.wg.Done()

--- a/dnscrypt-proxy/main.go
+++ b/dnscrypt-proxy/main.go
@@ -110,6 +110,7 @@ func (app *App) Stop(service service.Service) error {
 	if pidFilePath := pidfile.GetPidfilePath(); len(pidFilePath) > 1 {
 		os.Remove(pidFilePath)
 	}
+	killChild()
 	dlog.Notice("Stopped.")
 	return nil
 }

--- a/dnscrypt-proxy/privilege_others.go
+++ b/dnscrypt-proxy/privilege_others.go
@@ -14,6 +14,8 @@ import (
 	"github.com/jedisct1/dlog"
 )
 
+var cmd *exec.Cmd
+
 func (proxy *Proxy) dropPrivilege(userStr string, fds []*os.File) {
 	currentUser, err := user.Current()
 	if err != nil {
@@ -52,7 +54,7 @@ func (proxy *Proxy) dropPrivilege(userStr string, fds []*os.File) {
 
 	dlog.Notice("Dropping privileges")
 	for {
-		cmd := exec.Command(path, args...)
+		cmd = exec.Command(path, args...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		cmd.ExtraFiles = fds
@@ -64,4 +66,12 @@ func (proxy *Proxy) dropPrivilege(userStr string, fds []*os.File) {
 		time.Sleep(1 * time.Second)
 	}
 	os.Exit(0)
+}
+
+func killChild() {
+	if cmd != nil {
+		if err := cmd.Process.Kill(); err != nil {
+			dlog.Fatal("Failed to kill child process.")
+		}
+	}
 }

--- a/dnscrypt-proxy/privilege_others.go
+++ b/dnscrypt-proxy/privilege_others.go
@@ -15,6 +15,13 @@ import (
 )
 
 func (proxy *Proxy) dropPrivilege(userStr string, fds []*os.File) {
+	currentUser, err := user.Current()
+	if err != nil {
+		dlog.Fatal(err)
+	}
+	if currentUser.Uid != "0" {
+		dlog.Fatal("I need root permissions. Try again with 'sudo'")
+	}
 	user, err := user.Lookup(userStr)
 	args := os.Args
 

--- a/dnscrypt-proxy/privilege_windows.go
+++ b/dnscrypt-proxy/privilege_windows.go
@@ -3,3 +3,4 @@ package main
 import "os"
 
 func (proxy *Proxy) dropPrivilege(userStr string, fds []*os.File) {}
+func killChild() {}


### PR DESCRIPTION
I'm not sure if [kill](https://golang.org/pkg/os/#Process.Kill)ing the process is the best way to do it. Maybe we need to investigate if [cmd.Process.Wait()](https://golang.org/pkg/os/#Process.Wait) or [cmd.Wait()](https://golang.org/pkg/os/exec/#Cmd.Wait) is a better option.