### PR TITLE
a quick fix to dnscrypt-proxy old pledge call

### DIFF
--- a/dnscrypt-proxy/main.go
+++ b/dnscrypt-proxy/main.go
@@ -25,7 +25,10 @@ type App struct {
 func main() {
 	dlog.Init("dnscrypt-proxy", dlog.SeverityNotice, "DAEMON")
 
-	Pledge()
+	err := Pledge()
+	if err != nil {
+		dlog.Fatal("pledge() failed")
+	}
 
 	pwd, err := os.Getwd()
 	if err != nil {
@@ -37,6 +40,7 @@ func main() {
 		Description:      "Encrypted/authenticated DNS proxy",
 		WorkingDirectory: pwd,
 	}
+
 	svcFlag := flag.String("service", "", fmt.Sprintf("Control the system service: %q", service.ControlAction))
 	app := &App{}
 	svc, err := service.New(app, svcConfig)
@@ -44,6 +48,7 @@ func main() {
 		svc = nil
 		dlog.Debug(err)
 	}
+
 	app.proxy = NewProxy()
 	_ = ServiceManagerStartNotify()
 	if err := ConfigLoad(&app.proxy, svcFlag); err != nil {
@@ -72,6 +77,7 @@ func main() {
 		return
 	}
 	if svc != nil {
+
 		if err = svc.Run(); err != nil {
 			dlog.Fatal(err)
 		}

--- a/dnscrypt-proxy/pledge_openbsd.go
+++ b/dnscrypt-proxy/pledge_openbsd.go
@@ -6,10 +6,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Pledge() {
-	unix.Pledge("stdio rpath wpath cpath tmppath inet fattr flock dns getpw sendfd recvfd proc exec id", nil)
+func Pledge() error {
+	err := unix.Pledge("stdio rpath wpath cpath tmppath inet fattr flock dns getpw sendfd recvfd proc exec id unix", "stdio rpath wpath cpath tmppath inet fattr flock dns sendfd recvfd")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func PledgeChild() {
-	unix.Pledge("stdio rpath wpath cpath tmppath inet fattr flock dns recvfd", nil)
-}
+//func PledgeChild() {
+//	unix.Pledge("stdio rpath wpath cpath tmppath inet fattr flock dns recvfd", "stdio rpath wpath cpath tmppath inet fattr flock dns recvfd")
+//}

--- a/vendor/golang.org/x/sys/unix/openbsd_pledge.go
+++ b/vendor/golang.org/x/sys/unix/openbsd_pledge.go
@@ -17,20 +17,28 @@ const (
 )
 
 // Pledge implements the pledge syscall. For more information see pledge(2).
-func Pledge(promises string, paths []string) error {
+func Pledge(promises string, execpromises string) error {
 	promisesPtr, err := syscall.BytePtrFromString(promises)
 	if err != nil {
 		return err
 	}
-	promisesUnsafe, pathsUnsafe := unsafe.Pointer(promisesPtr), unsafe.Pointer(nil)
-	if paths != nil {
-		var pathsPtr []*byte
-		if pathsPtr, err = syscall.SlicePtrFromStrings(paths); err != nil {
-			return err
+	/*
+		if paths != nil {
+			var pathsPtr []*byte
+			if pathsPtr, err = syscall.SlicePtrFromStrings(paths); err != nil {
+				return err
+			}
+			pathsUnsafe = unsafe.Pointer(&pathsPtr[0])
 		}
-		pathsUnsafe = unsafe.Pointer(&pathsPtr[0])
+	*/
+
+	execPromisesPtr, err := syscall.BytePtrFromString(execpromises)
+	if err != nil {
+		return err
 	}
-	_, _, e := syscall.Syscall(_SYS_PLEDGE, uintptr(promisesUnsafe), uintptr(pathsUnsafe), 0)
+	promisesUnsafe, execPromisesUnsafe := unsafe.Pointer(promisesPtr), unsafe.Pointer(execPromisesPtr)
+
+	_, _, e := syscall.Syscall(_SYS_PLEDGE, uintptr(promisesUnsafe), uintptr(execPromisesUnsafe), 0)
 	if e != 0 {
 		return e
 	}


### PR DESCRIPTION
pledge(2) in 6.3 evolved as unveil(2) is coming in 6.4
as it was killed during the attempt to run it, quick investigation showed that pledge call was the old prototype of the (6.2) pledge(2) call.
In addition the proper restrictions have not been completely investigated but were missing "unix" pledge since the hashicorp gsyslog wrapper code is NOT using log/syslog but implement a socket()/connect() call to a "unix" socket... hence the pledge update
the author probably know better all the intricacies required, it seems to run properly now.
did not change the building travis-ci stuff, I'm not using it extensively.
please let me know if this is correct, hope this helps.