### PR TITLE
Correct CoinblockerLists URL

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -93,8 +93,8 @@ http://someonewhocares.org/hosts/hosts
 # NoTracking's list - blocking ads, trackers and other online garbage
 https://raw.githubusercontent.com/notracking/hosts-blocklists/master/domains.txt
 
-# CoinBlockerLists: blocks websites serving cryptocurrency miners - https://zerodot1.github.io/CoinBlockerLists/ - Contains false positives
-# https://raw.githubusercontent.com/ZeroDot1/CoinBlockerLists/master/list_browser.txt
+# CoinBlockerLists: blocks websites serving cryptocurrency miners - https://gitlab.com/ZeroDot1/CoinBlockerLists/ - Contains false positives
+# https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/list_browser.txt
 
 # Websites potentially publishing fake news
 # https://raw.githubusercontent.com/marktron/fakenews/master/fakenews


### PR DESCRIPTION
CoinblockerLists has moved to GitLab, the old link 404s.