### PR TITLE
Make PluginGetSetPayloadSize toggle-able

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	NetprobeAddress          string                     `toml:"netprobe_address"`
 	NetprobeTimeout          int                        `toml:"netprobe_timeout"`
 	OfflineMode              bool                       `toml:"offline_mode"`
+	GetSetPayload            bool                       `toml:"get_set_payload"`
 }
 
 func newConfig() Config {
@@ -106,6 +107,7 @@ func newConfig() Config {
 		NetprobeAddress:          "9.9.9.9:53",
 		NetprobeTimeout:          30,
 		OfflineMode:              false,
+		GetSetPayload:            true,
 	}
 }
 
@@ -304,6 +306,7 @@ func ConfigLoad(proxy *Proxy, svcFlag *string) error {
 	proxy.pluginBlockIPv6 = config.BlockIPv6
 	proxy.cache = config.Cache
 	proxy.cacheSize = config.CacheSize
+	proxy.getSetPayload = config.GetSetPayload
 
 	if config.CacheNegTTL > 0 {
 		proxy.cacheNegMinTTL = config.CacheNegTTL

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -84,7 +84,9 @@ func InitPluginsGlobals(pluginsGlobals *PluginsGlobals, proxy *Proxy) error {
 	if len(proxy.cloakFile) != 0 {
 		*queryPlugins = append(*queryPlugins, Plugin(new(PluginCloak)))
 	}
-	*queryPlugins = append(*queryPlugins, Plugin(new(PluginGetSetPayloadSize)))
+	if proxy.getSetPayload {
+		*queryPlugins = append(*queryPlugins, Plugin(new(PluginGetSetPayloadSize)))
+	}
 	if proxy.cache {
 		*queryPlugins = append(*queryPlugins, Plugin(new(PluginCache)))
 	}

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -63,6 +63,7 @@ type Proxy struct {
 	logMaxSize                   int
 	logMaxAge                    int
 	logMaxBackups                int
+	getSetPayload                bool
 }
 
 func (proxy *Proxy) StartProxy() {


### PR DESCRIPTION
This strips EDNS data that you may want to pass upstream.  This PR just makes it a toggleable option.

All plugins are now toggleable via configuration option of some kind or another.