### PR TITLE
Use Android NDK r18, use API 19 for 32-bit Android builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -195,14 +195,16 @@ before_deploy:
 after_deploy:
 - ls -l dnscrypt-proxy-*.tar.gz dnscrypt-proxy-*.zip
 before_install:
-- NDK_VER=r18-beta2
+- NDK_VER=r18
 - curl -LO http://dl.google.com/android/repository/android-ndk-${NDK_VER}-linux-x86_64.zip
 - unzip -q android-ndk-${NDK_VER}-linux-x86_64.zip -d $HOME
 - rm android-ndk-${NDK_VER}-linux-x86_64.zip
 - NDK_TOOLS=$HOME/android-ndk-${NDK_VER}
 - NDK_STANDALONE=$HOME/ndk-standalone-${NDK_VER}
 - MAKE_TOOLCHAIN=$NDK_TOOLS/build/tools/make_standalone_toolchain.py
-- for arch in x86 x86_64 arm arm64; do python $MAKE_TOOLCHAIN --arch $arch --api 21
+- for arch in x86 arm; do python $MAKE_TOOLCHAIN --arch $arch --api 19
+  --install-dir $NDK_STANDALONE/$arch; PATH=$PATH:$NDK_STANDALONE/$arch/bin; done
+- for arch in x86_64 arm64; do python $MAKE_TOOLCHAIN --arch $arch --api 21
   --install-dir $NDK_STANDALONE/$arch; PATH=$PATH:$NDK_STANDALONE/$arch/bin; done
 - rm -rf $NDK_TOOLS
 env:


### PR DESCRIPTION
Older androids had some function like `sigfillset` implemented as macros, and `android-19` is 
the last backward-compatible and forward-compatible version of unified headers.

https://github.com/jedisct1/dnscrypt-proxy/issues/608