### PR TITLE
Removed securemecca.com as it has expired and does not currently host…

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist-all.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist-all.conf
@@ -85,7 +85,6 @@ http://mirror1.malwaredomains.com/files/dynamic_dns.txt
 # Block pornography
 https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/0.0.0.0/hosts
 https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/pornography-hosts
-http://securemecca.com/Downloads/hosts.txt
 
 # Block gambling sites
 https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/gambling-hosts

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -108,7 +108,6 @@ https://raw.githubusercontent.com/notracking/hosts-blocklists/master/domains.txt
 # Block pornography
 # https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/0.0.0.0/hosts
 # https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/pornography-hosts
-# http://securemecca.com/Downloads/hosts.txt
 
 # Block gambling sites
 # https://raw.githubusercontent.com/Sinfonietta/hostfiles/master/gambling-hosts


### PR DESCRIPTION
Securemecca.com domain has expired and does not currently host any blacklist content.  As such it should be removed from config files.