### PR TITLE
Minor domains-blacklist fixes

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist-all.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist-all.conf
@@ -23,7 +23,7 @@ file:domains-blacklist-local-additions.txt
 http://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt
 
 # hpHosts’ Ad and tracking servers
-http://hosts-file.net/.%5Cad_servers.txt
+http://hosts-file.net/ad_servers.txt
 
 # Malware domains
 http://mirror1.malwaredomains.com/files/justdomains

--- a/utils/generate-domains-blacklists/domains-blacklist-all.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist-all.conf
@@ -20,19 +20,19 @@
 file:domains-blacklist-local-additions.txt
 
 # Bambenek malware C2s
-http://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt
+https://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt
 
 # hpHosts’ Ad and tracking servers
-http://hosts-file.net/ad_servers.txt
+https://hosts-file.net/ad_servers.txt
 
 # Malware domains
-http://mirror1.malwaredomains.com/files/justdomains
+https://mirror1.malwaredomains.com/files/justdomains
 
 # Abuse.ch Ransomware Tracker
-http://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt
+https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt
 
 # Malware Domain List
-http://www.malwaredomainlist.com/mdlcsv.php?inactive=off
+https://www.malwaredomainlist.com/mdlcsv.php?inactive=off
 
 # Adblock Warning Removal List
 https://easylist-downloads.adblockplus.org/antiadblockfilters.txt
@@ -80,7 +80,7 @@ https://raw.githubusercontent.com/azet12/KADhosts/master/KADhosts.txt
 https://raw.githubusercontent.com/marktron/fakenews/master/fakenews
 
 # Dynamic DNS services, sadly often used by malware
-http://mirror1.malwaredomains.com/files/dynamic_dns.txt
+https://mirror1.malwaredomains.com/files/dynamic_dns.txt
 
 # Block pornography
 https://raw.githubusercontent.com/Clefspeare13/pornhosts/master/0.0.0.0/hosts

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -31,7 +31,7 @@ file:domains-blacklist-local-additions.txt
 https://osint.bambenekconsulting.com/feeds/c2-dommasterlist.txt
 
 # hpHosts’ Ad and tracking servers
-https://hosts-file.net/.%5Cad_servers.txt
+https://hosts-file.net/ad_servers.txt
 
 # Malware domains
 https://mirror1.malwaredomains.com/files/justdomains

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -40,7 +40,7 @@ https://mirror1.malwaredomains.com/files/justdomains
 https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt
 
 # Malware Domain List
-http://www.malwaredomainlist.com/mdlcsv.php?inactive=off
+https://www.malwaredomainlist.com/mdlcsv.php?inactive=off
 
 # Adblock Warning Removal List
 https://easylist-downloads.adblockplus.org/antiadblockfilters.txt


### PR DESCRIPTION
## Changes

I noticed that `https` was on a few URLs in `domains-blacklist.conf` that weren't in `domains-blacklist-all.conf` and one that wasn't in both (`www.malwaredomainlist.com`).

I also noticed there was the characters `.\` in the `hosts-file.net` URLs, which I assume was just a typo.

## Notes

I tested each URL in browser and then with `./generate-domains-blacklist.py -c domains-blacklist-all.conf` which didn't seem to result in any errors.