### PR TITLE
logging enhancement CLOAK

### DIFF
--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -185,5 +185,6 @@ func (plugin *PluginCloak) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 	}
 	pluginsState.synthResponse = synth
 	pluginsState.action = PluginsActionSynth
+	pluginsState.returnCode = PluginsReturnCodeCloak
 	return nil
 }

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -39,6 +39,7 @@ const (
 	PluginsReturnCodeNXDomain
 	PluginsReturnCodeResponseError
 	PluginsReturnCodeServerError
+	PluginsReturnCodeCloak
 )
 
 var PluginsReturnCodeToString = map[PluginsReturnCode]string{
@@ -51,6 +52,7 @@ var PluginsReturnCodeToString = map[PluginsReturnCode]string{
 	PluginsReturnCodeNXDomain:      "NXDOMAIN",
 	PluginsReturnCodeResponseError: "RESPONSE_ERROR",
 	PluginsReturnCodeServerError:   "SERVER_ERROR",
+	PluginsReturnCodeCloak:         "CLOAK",
 }
 
 type PluginsState struct {


### PR DESCRIPTION
Currently responses that have been modified by plugins_cloak show up as PASS in the log.  Create a new PluginsReturnCodeCloak so cloaked responses are logged as CLOAK