### PR TITLE
Replace “find” with “findstr” in batches

### DIFF
--- a/windows/service-install.bat
+++ b/windows/service-install.bat
@@ -3,7 +3,7 @@
 setlocal EnableExtensions
 title DNSCrypt-Proxy
 
-whoami /groups | find "S-1-16-12288" >nul && goto :admin
+whoami /groups | findstr "S-1-16-12288" >nul && goto :admin
 if "%~1"=="RunAsAdmin" goto :error
 
 echo Requesting privileges elevation for managing the dnscrypt-proxy service . . .

--- a/windows/service-restart.bat
+++ b/windows/service-restart.bat
@@ -3,7 +3,7 @@
 setlocal EnableExtensions
 title DNSCrypt-Proxy
 
-whoami /groups | find "S-1-16-12288" >nul && goto :admin
+whoami /groups | findstr "S-1-16-12288" >nul && goto :admin
 if "%~1"=="RunAsAdmin" goto :error
 
 echo Requesting privileges elevation for managing the dnscrypt-proxy service . . .

--- a/windows/service-uninstall.bat
+++ b/windows/service-uninstall.bat
@@ -3,7 +3,7 @@
 setlocal EnableExtensions
 title DNSCrypt-Proxy
 
-whoami /groups | find "S-1-16-12288" >nul && goto :admin
+whoami /groups | findstr "S-1-16-12288" >nul && goto :admin
 if "%~1"=="RunAsAdmin" goto :error
 
 echo Requesting privileges elevation for managing the dnscrypt-proxy service . . .


### PR DESCRIPTION
DNSCrypt-Proxy 2.0.8 was the last release which didn’t use “find”, then it was introduced. And up to this day (2.0.21) I had to replace “find” with “findstr” in batches, because “find” doesn’t work when codepage is 65001 (Unicode). The proposed change is intended to correct this misunderstanding once and for all.