### PR TITLE
make generate-domains-blacklist.py compatible to both python2 and python3

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist-all.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist-all.conf
@@ -68,7 +68,7 @@ https://s3.amazonaws.com/lists.disconnect.me/simple_malware.txt
 https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
 
 # Quidsup NoTrack
-https://raw.githubusercontent.com/quidsup/notrack/master/trackers.txt
+https://gitlab.com/quidsup/notrack-blocklists/raw/master/notrack-blocklist.txt
 
 # Sysctl list (ads)
 http://sysctl.org/cameleon/hosts

--- a/utils/generate-domains-blacklists/generate-domains-blacklist.py
+++ b/utils/generate-domains-blacklists/generate-domains-blacklist.py
@@ -111,6 +111,7 @@ def load_from_url(url):
 
     return (content, trusted)
 
+
 def name_cmp(name):
     parts = name.split(".")
     parts.reverse()


### PR DESCRIPTION
Pretty much as the title says. I also fixed a dead URL in domains-blacklist-all.conf, it moved to Gitlab [LINK](https://github.com/quidsup/notrack/)