### PR TITLE
Whitelist Server Source Domains

### DIFF
--- a/utils/generate-domains-blacklists/domains-whitelist.txt
+++ b/utils/generate-domains-blacklists/domains-whitelist.txt
@@ -4,10 +4,12 @@ appsflyer.com
 azurewebsites.net
 cdnetworks.com
 cloudapp.net
+download.dnscrypt.info
 edgekey.net
 elasticbeanstalk.com
 github.com
 github.io
+raw.githubusercontent.com
 invalid
 j.mp
 l-msedge.net


### PR DESCRIPTION
A malicious blacklist, or accidental block, could prevent dnscrypt-proxy users from being able to fetch public resolvers and important certificate updates. Both URLs are taken from the default config:

[sources.'public-resolvers']
urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v2/public-resolvers.md', 'https://download.dnscrypt.info/resolvers-list/v2/public-resolvers.md']