### PR TITLE
Enhance logging

### DIFF
--- a/dnscrypt-proxy/plugin_forward.go
+++ b/dnscrypt-proxy/plugin_forward.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"net"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/jedisct1/dlog"
@@ -92,7 +93,9 @@ func (plugin *PluginForward) Eval(pluginsState *PluginsState, msg *dns.Msg) erro
 		return nil
 	}
 	server := servers[rand.Intn(len(servers))]
+	reqStart := time.Now()
 	respMsg, err := dns.Exchange(msg, server)
+	pluginsState.forwardDuration = time.Now().Sub(reqStart)
 	if err != nil {
 		return err
 	}

--- a/dnscrypt-proxy/plugin_query_log.go
+++ b/dnscrypt-proxy/plugin_query_log.go
@@ -71,16 +71,22 @@ func (plugin *PluginQueryLog) Eval(pluginsState *PluginsState, msg *dns.Msg) err
 		returnCode = string(returnCode)
 	}
 
+	var requestDuration, forwardDuration time.Duration
+	if !pluginsState.requestStart.IsZero() && !pluginsState.requestEnd.IsZero() {
+		requestDuration = pluginsState.requestEnd.Sub(pluginsState.requestStart)
+	}
+	forwardDuration = pluginsState.forwardDuration
+
 	var line string
 	if plugin.format == "tsv" {
 		now := time.Now()
 		year, month, day := now.Date()
 		hour, minute, second := now.Clock()
 		tsStr := fmt.Sprintf("[%d-%02d-%02d %02d:%02d:%02d]", year, int(month), day, hour, minute, second)
-		line = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\n", tsStr, clientIPStr, StringQuote(qName), qType, returnCode)
+		line = fmt.Sprintf("%s\t%s\t%s\t%s\t%s\t%v\t%v\n", tsStr, clientIPStr, StringQuote(qName), qType, returnCode, requestDuration, forwardDuration)
 	} else if plugin.format == "ltsv" {
-		line = fmt.Sprintf("time:%d\thost:%s\tmessage:%s\ttype:%s\treturn:%s\n",
-			time.Now().Unix(), clientIPStr, StringQuote(qName), qType, returnCode)
+		line = fmt.Sprintf("time:%d\thost:%s\tmessage:%s\ttype:%s\treturn:%s\treqDuration:%d\tfwdDuration:%d\n",
+			time.Now().Unix(), clientIPStr, StringQuote(qName), qType, returnCode, requestDuration.Nanoseconds(), forwardDuration.Nanoseconds())
 	} else {
 		dlog.Fatalf("Unexpected log format: [%s]", plugin.format)
 	}


### PR DESCRIPTION
Enhance query logging by adding:
* Total request time
   The duration between dnscrypt-proxy receiving the request and it sending the response
* Upstream request time
   The duration between sending a request to an upstream DNS server and us receiving the response. Including requests forwarded based on `forwarding_rules`.
