### PR TITLE
regex isn't fully parsing the complicated csv file

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -40,7 +40,7 @@ https://mirror1.malwaredomains.com/files/justdomains
 https://ransomwaretracker.abuse.ch/downloads/RW_DOMBL.txt
 
 # Malware Domain List
-https://www.malwaredomainlist.com/mdlcsv.php?inactive=off
+https://www.malwaredomainlist.com/hostslist/hosts.txt
 
 # Adblock Warning Removal List
 https://easylist-downloads.adblockplus.org/antiadblockfilters.txt


### PR DESCRIPTION
Not all URLs are extracted from the complicated csv file.
However, they do offer a txt file for the same list, which does work correctly with the current regex:
https://www.malwaredomainlist.com/forums/index.php?topic=3270.0
This url replacement pull request is easier than rewriting the entire regex (which then breaks other lists).