### PR TITLE
netProbe: Always log Network connectivity detected

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -635,9 +635,7 @@ func netProbe(address string, timeout int) error {
 			continue
 		}
 		pc.Close()
-		if retried {
-			dlog.Notice("Network connectivity detected")
-		}
+		dlog.Notice("Network connectivity detected")
 		return nil
 	}
 	es := "Timeout while waiting for network connectivity"


### PR DESCRIPTION
In the netProb function, always log whether network connectivity is detected or not.