### PR TITLE
Fix netProbe write check

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -623,7 +623,10 @@ func netProbe(address string, timeout int) error {
 	for tries := timeout; tries > 0; tries-- {
 		pc, err := net.DialUDP("udp", nil, remoteUDPAddr)
 		if err == nil {
-			_, err = pc.Write([]byte{})
+			// Write at least 1 byte. This ensures that sockets are ready to use for writing.
+			// Windows specific: during the system startup, sockets can be created but the underlying buffers may not be setup yet. If this is the case
+			// Write fails with WSAENOBUFS: "An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full"
+			_, err = pc.Write([]byte{ 0 })
 		}
 		if err != nil {
 			if !retried {


### PR DESCRIPTION
Write at least 1 byte. This ensures that sockets are ready to use for writing.
Windows specific: during the system startup, sockets can be created but the underlying buffers may not be setup yet. If this is the case Write fails with WSAENOBUFS: "An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full
This fixes: https://github.com/jedisct1/dnscrypt-proxy/issues/841