### PR TITLE
Option to redirect refused responses to a given IP address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *~
 dnscrypt-proxy/dnscrypt-proxy2
 dnscrypt-proxy/dnscrypt-proxy
+.idea

--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	OfflineMode              bool                       `toml:"offline_mode"`
 	HTTPProxyURL             string                     `toml:"http_proxy"`
 	RefusedCodeInResponses   bool                       `toml:"refused_code_in_responses"`
+	RespondWithIP            string                     `toml:"respond_with_ip"`
 }
 
 func newConfig() Config {
@@ -290,6 +291,7 @@ func ConfigLoad(proxy *Proxy, svcFlag *string) error {
 	proxy.xTransport.rebuildTransport()
 
 	proxy.refusedCodeInResponses = config.RefusedCodeInResponses
+	proxy.respondWithIP = config.RespondWithIP
 	proxy.timeout = time.Duration(config.Timeout) * time.Millisecond
 	proxy.maxClients = config.MaxClients
 	proxy.mainProto = "udp"

--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	OfflineMode              bool                       `toml:"offline_mode"`
 	HTTPProxyURL             string                     `toml:"http_proxy"`
 	RefusedCodeInResponses   bool                       `toml:"refused_code_in_responses"`
-	RespondWithIP            string                     `toml:"respond_with_ip"`
+	BlockedQueryResponse     string                     `toml:"blocked_query_response"`
 }
 
 func newConfig() Config {
@@ -118,6 +118,7 @@ func newConfig() Config {
 		OfflineMode:              false,
 		RefusedCodeInResponses:   false,
 		LBEstimator:              true,
+		BlockedQueryResponse:     "hinfo",
 	}
 }
 
@@ -290,8 +291,15 @@ func ConfigLoad(proxy *Proxy, svcFlag *string) error {
 
 	proxy.xTransport.rebuildTransport()
 
-	proxy.refusedCodeInResponses = config.RefusedCodeInResponses
-	proxy.respondWithIP = config.RespondWithIP
+	if md.IsDefined("refused_code_in_responses") {
+		dlog.Notice("config option `refused_code_in_responses` is deprecated, use `blocked_query_response`")
+		if config.RefusedCodeInResponses {
+			config.BlockedQueryResponse = "refused"
+		} else {
+			config.BlockedQueryResponse = "hinfo"
+		}
+	}
+	proxy.blockedQueryResponse = config.BlockedQueryResponse
 	proxy.timeout = time.Duration(config.Timeout) * time.Millisecond
 	proxy.maxClients = config.MaxClients
 	proxy.mainProto = "udp"

--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -32,7 +32,7 @@ func EmptyResponseFromMessage(srcMsg *dns.Msg) (*dns.Msg, error) {
 	return dstMsg, nil
 }
 
-func RefusedResponseFromMessage(srcMsg *dns.Msg, refusedCode bool, ip net.IP, ttl uint32) (*dns.Msg, error) {
+func RefusedResponseFromMessage(srcMsg *dns.Msg, refusedCode bool, ipv4 net.IP, ipv6 net.IP, ttl uint32) (*dns.Msg, error) {
 	dstMsg, err := EmptyResponseFromMessage(srcMsg)
 	if err != nil {
 		return dstMsg, err
@@ -46,24 +46,21 @@ func RefusedResponseFromMessage(srcMsg *dns.Msg, refusedCode bool, ip net.IP, tt
 			question := questions[0]
 			sendHInfoResponse := true
 
-			if ip != nil {
-				if question.Qtype == dns.TypeA {
-					rr := new(dns.A)
-					rr.Hdr = dns.RR_Header{Name: question.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl}
-					rr.A = ip.To4()
-					if rr.A != nil {
-						dstMsg.Answer = []dns.RR{rr}
-						sendHInfoResponse = false
-					}
-
-				} else if question.Qtype == dns.TypeAAAA {
-					rr := new(dns.AAAA)
-					rr.Hdr = dns.RR_Header{Name: question.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: ttl}
-					rr.AAAA = ip.To16()
-					if rr.AAAA != nil {
-						dstMsg.Answer = []dns.RR{rr}
-						sendHInfoResponse = false
-					}
+			if ipv4 != nil && question.Qtype == dns.TypeA {
+				rr := new(dns.A)
+				rr.Hdr = dns.RR_Header{Name: question.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl}
+				rr.A = ipv4.To4()
+				if rr.A != nil {
+					dstMsg.Answer = []dns.RR{rr}
+					sendHInfoResponse = false
+				}
+			} else if ipv6 != nil && question.Qtype == dns.TypeAAAA {
+				rr := new(dns.AAAA)
+				rr.Hdr = dns.RR_Header{Name: question.Name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: ttl}
+				rr.AAAA = ipv6.To16()
+				if rr.AAAA != nil {
+					dstMsg.Answer = []dns.RR{rr}
+					sendHInfoResponse = false
 				}
 			}
 

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -111,17 +111,12 @@ timeout = 2500
 keepalive = 30
 
 
-## Use the REFUSED return code for blocked responses
-## Setting this to `false` means that some responses will be lies.
-## Unfortunately, `false` appears to be required for Android 8+
+## Response for blocked queries.  Options are `refused`, `hinfo` (default) or
+## an IP address (e.g. local pixelserv-tls server).  Using the `hinfo` option
+## means that some responses will be lies. Unfortunately, the `hinfo` option
+## appears to be required for Android 8+
 
-refused_code_in_responses = false
-
-## If refused_code_in_responses is `false`, use this optional setting
-## to redirect blocked respones to an IP address (e.g. pixelserv-tls)
-## instead of returning an HINFO record
-
-# respond_with_ip = '192.168.1.4'
+# blocked_query_response = 'refused'
 
 
 ## Load-balancing strategy: 'p2' (default), 'ph', 'first' or 'random'

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -117,6 +117,12 @@ keepalive = 30
 
 refused_code_in_responses = false
 
+## If refused_code_in_responses is `false`, use this optional setting
+## to redirect blocked respones to an IP address (e.g. pixelserv-tls)
+## instead of returning an HINFO record
+
+# respond_with_ip = '192.168.1.4'
+
 
 ## Load-balancing strategy: 'p2' (default), 'ph', 'first' or 'random'
 

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -112,9 +112,9 @@ keepalive = 30
 
 
 ## Response for blocked queries.  Options are `refused`, `hinfo` (default) or
-## an IP address (e.g. local pixelserv-tls server).  Using the `hinfo` option
-## means that some responses will be lies. Unfortunately, the `hinfo` option
-## appears to be required for Android 8+
+## an IP response.  To give an IP response, use the format `a:<IPv4>,aaaa:<IPv6>`.
+## Using the `hinfo` option means that some responses will be lies.
+## Unfortunately, the `hinfo` option appears to be required for Android 8+
 
 # blocked_query_response = 'refused'
 

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -136,8 +136,21 @@ func InitPluginsGlobals(pluginsGlobals *PluginsGlobals, proxy *Proxy) error {
 	(*pluginsGlobals).queryPlugins = queryPlugins
 	(*pluginsGlobals).responsePlugins = responsePlugins
 	(*pluginsGlobals).loggingPlugins = loggingPlugins
-	(*pluginsGlobals).refusedCodeInResponses = proxy.refusedCodeInResponses
-	(*pluginsGlobals).respondWithIP = net.ParseIP(proxy.respondWithIP)
+
+	// blockedQueryResponse can be 'refused', 'hinfo' or an IP address
+	(*pluginsGlobals).respondWithIP = net.ParseIP(proxy.blockedQueryResponse)
+	if (*pluginsGlobals).respondWithIP == nil {
+		switch proxy.blockedQueryResponse {
+		case "refused":
+			(*pluginsGlobals).refusedCodeInResponses = true
+		case "hinfo":
+			(*pluginsGlobals).refusedCodeInResponses = false
+		default:
+			dlog.Noticef("Invalid blocked_query_response option [%s], defaulting to `hinfo`", proxy.blockedQueryResponse)
+			(*pluginsGlobals).refusedCodeInResponses = false
+		}
+	}
+
 	return nil
 }
 

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -26,6 +26,7 @@ type PluginsGlobals struct {
 	responsePlugins        *[]Plugin
 	loggingPlugins         *[]Plugin
 	refusedCodeInResponses bool
+	respondWithIP          net.IP
 }
 
 type PluginsReturnCode int
@@ -136,6 +137,7 @@ func InitPluginsGlobals(pluginsGlobals *PluginsGlobals, proxy *Proxy) error {
 	(*pluginsGlobals).responsePlugins = responsePlugins
 	(*pluginsGlobals).loggingPlugins = loggingPlugins
 	(*pluginsGlobals).refusedCodeInResponses = proxy.refusedCodeInResponses
+	(*pluginsGlobals).respondWithIP = net.ParseIP(proxy.respondWithIP)
 	return nil
 }
 
@@ -186,7 +188,7 @@ func (pluginsState *PluginsState) ApplyQueryPlugins(pluginsGlobals *PluginsGloba
 			return packet, ret
 		}
 		if pluginsState.action == PluginsActionReject {
-			synth, err := RefusedResponseFromMessage(&msg, pluginsGlobals.refusedCodeInResponses)
+			synth, err := RefusedResponseFromMessage(&msg, pluginsGlobals.refusedCodeInResponses, pluginsGlobals.respondWithIP, pluginsState.cacheMinTTL)
 			if err != nil {
 				return nil, err
 			}
@@ -234,7 +236,7 @@ func (pluginsState *PluginsState) ApplyResponsePlugins(pluginsGlobals *PluginsGl
 			return packet, ret
 		}
 		if pluginsState.action == PluginsActionReject {
-			synth, err := RefusedResponseFromMessage(&msg, pluginsGlobals.refusedCodeInResponses)
+			synth, err := RefusedResponseFromMessage(&msg, pluginsGlobals.refusedCodeInResponses, pluginsGlobals.respondWithIP, pluginsState.cacheMinTTL)
 			if err != nil {
 				return nil, err
 			}

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -64,6 +64,7 @@ type Proxy struct {
 	logMaxAge                    int
 	logMaxBackups                int
 	refusedCodeInResponses       bool
+	respondWithIP                string
 	showCerts                    bool
 }
 

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -63,8 +63,7 @@ type Proxy struct {
 	logMaxSize                   int
 	logMaxAge                    int
 	logMaxBackups                int
-	refusedCodeInResponses       bool
-	respondWithIP                string
+	blockedQueryResponse         string
 	showCerts                    bool
 }
 


### PR DESCRIPTION
This might be too specific of a use case, so I won't be offended if you don't want to merge this.

I run a pixelserv-tls server (https://github.com/kvic-z/pixelserv-tls) to respond to add/trackers with a blank pixel, so I modified the option `refused_code_in_responses` to be able to take an IP address (in addition to 'refused' or the 'hinfo' response similar to before).

Since the config option is a new type (string vs bool), I changed the name to `blocked_query_response` but still support `refused_code_in_responses` with a deprecated message.