### PR TITLE
feature: service_linux: Support systemd watchdog

### DIFF
--- a/dnscrypt-proxy/privilege_linux.go
+++ b/dnscrypt-proxy/privilege_linux.go
@@ -47,7 +47,9 @@ func (proxy *Proxy) dropPrivilege(userStr string, fds []*os.File) {
 		dlog.Fatal(err)
 	}
 
-	ServiceManagerReadyNotify()
+	if err := ServiceManagerReadyNotify(); err != nil {
+		dlog.Fatal(err)
+	}
 
 	args = append(args, "-child")
 

--- a/dnscrypt-proxy/privilege_others.go
+++ b/dnscrypt-proxy/privilege_others.go
@@ -48,7 +48,9 @@ func (proxy *Proxy) dropPrivilege(userStr string, fds []*os.File) {
 		dlog.Fatal(err)
 	}
 
-	ServiceManagerReadyNotify()
+	if err := ServiceManagerReadyNotify(); err != nil {
+		dlog.Fatal(err)
+	}
 
 	args = append(args, "-child")
 

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -164,7 +164,9 @@ func (proxy *Proxy) StartProxy() {
 	if liveServers > 0 {
 		dlog.Noticef("dnscrypt-proxy is ready - live servers: %d", liveServers)
 		if !proxy.child {
-			ServiceManagerReadyNotify()
+			if err := ServiceManagerReadyNotify(); err != nil {
+				dlog.Fatal(err)
+			}
 		}
 	} else if err != nil {
 		dlog.Error(err)

--- a/dnscrypt-proxy/service_android.go
+++ b/dnscrypt-proxy/service_android.go
@@ -6,5 +6,6 @@ func ServiceManagerStartNotify() error {
 	return nil
 }
 
-func ServiceManagerReadyNotify() {
+func ServiceManagerReadyNotify() error {
+	return nil
 }

--- a/dnscrypt-proxy/service_linux.go
+++ b/dnscrypt-proxy/service_linux.go
@@ -2,13 +2,36 @@
 
 package main
 
-import "github.com/coreos/go-systemd/daemon"
+import (
+	"github.com/coreos/go-systemd/daemon"
+	clocksmith "github.com/jedisct1/go-clocksmith"
+)
 
 func ServiceManagerStartNotify() error {
 	daemon.SdNotify(false, "STATUS=Starting")
 	return nil
 }
 
-func ServiceManagerReadyNotify() {
+func ServiceManagerReadyNotify() error {
 	daemon.SdNotify(false, "READY=1")
+	return systemDWatchdog()
+}
+
+func systemDWatchdog() error {
+	watchdogFailureDelay, err := daemon.SdWatchdogEnabled(false)
+	if err != nil || watchdogFailureDelay == 0 {
+		return err
+	}
+	refreshInterval := watchdogFailureDelay / 3
+	go func() {
+		for {
+			// TODO There could be other checks this just
+			// checks program is not totally stuck and can
+			// run this goroutine
+			daemon.SdNotify(false, "WATCHDOG=1")
+			clocksmith.Sleep(refreshInterval)
+		}
+
+	}()
+	return nil
 }

--- a/dnscrypt-proxy/service_others.go
+++ b/dnscrypt-proxy/service_others.go
@@ -6,5 +6,6 @@ func ServiceManagerStartNotify() error {
 	return nil
 }
 
-func ServiceManagerReadyNotify() {
+func ServiceManagerReadyNotify() error {
+	return nil
 }

--- a/dnscrypt-proxy/service_windows.go
+++ b/dnscrypt-proxy/service_windows.go
@@ -11,4 +11,6 @@ func ServiceManagerStartNotify() error {
 	return nil
 }
 
-func ServiceManagerReadyNotify() {}
+func ServiceManagerReadyNotify() error {
+	return nil
+}


### PR DESCRIPTION
Can be easily tested with this kind of command:

```
systemctl reset-failed --user
systemd-run --user --unit=foo --property={NotifyAccess=main,WatchdogSec=1m} --working-directory="$(readlink -f dnscrypt-proxy)" "$(readlink -f dnscrypt-proxy)"/dnscrypt-proxy-linux-amd64 -config example-dnscrypt-proxy.toml
```

Without this patch program is killed after minute. Like this:

Oct 18 22:15:43 workstation.lan systemd[1218]: foo.service: Watchdog timeout (limit 1min)!

I have this running with this in dnscrypt-proxy.service:

```
[Service]
NotifyAccess=main
WatchdogSec=3m
Restart=on-failure
...
```

As I mention in TODO comment, this probably does not hande every problem but I guess it does not hurt. If there is other internal metric to be sure the program is working it should transmitted there. As there is no such thing now, I used this simplest setup.

I decided to signal watchdog 3 times per period, just to be sure.