### PR TITLE
differentiate between timeout and other error for dnscrypt servers

### DIFF
--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -44,6 +44,7 @@ const (
 	PluginsReturnCodeResponseError
 	PluginsReturnCodeServerError
 	PluginsReturnCodeCloak
+	PluginsReturnCodeServerTimeout
 )
 
 var PluginsReturnCodeToString = map[PluginsReturnCode]string{
@@ -57,6 +58,7 @@ var PluginsReturnCodeToString = map[PluginsReturnCode]string{
 	PluginsReturnCodeResponseError: "RESPONSE_ERROR",
 	PluginsReturnCodeServerError:   "SERVER_ERROR",
 	PluginsReturnCodeCloak:         "CLOAK",
+	PluginsReturnCodeServerTimeout: "SERVER_TIMEOUT",
 }
 
 type PluginsState struct {

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -417,7 +417,11 @@ func (proxy *Proxy) processIncomingQuery(serverInfo *ServerInfo, clientProto str
 				response, err = proxy.exchangeWithTCPServer(serverInfo, sharedKey, encryptedQuery, clientNonce)
 			}
 			if err != nil {
-				pluginsState.returnCode = PluginsReturnCodeServerError
+				if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
+					pluginsState.returnCode = PluginsReturnCodeServerTimeout
+				} else {
+					pluginsState.returnCode = PluginsReturnCodeServerError
+				}
 				pluginsState.ApplyLoggingPlugins(&proxy.pluginsGlobals)
 				serverInfo.noticeFailure(proxy)
 				return


### PR DESCRIPTION
As per the suggestion of @PeterDaveHello in #924 this PR will print `SERVER_TIMEOUT` in the log if the error coming back from a DNSCrypt server is a net error with timeout flag.

I didn't change it for DoH because I had a look through the code and am not sure if a net error would get propagated back up to `proxy.go`.