### PR TITLE
move ConfigLoad into Start function when running as a service

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -211,7 +211,7 @@ func findConfigFile(configFile *string) (string, error) {
 	return path.Join(pwd, *configFile), nil
 }
 
-func ConfigLoad(proxy *Proxy, svcFlag *string) error {
+func ConfigLoad(proxy *Proxy) error {
 	version := flag.Bool("version", false, "print current proxy version")
 	resolve := flag.String("resolve", "", "resolve a name using system libraries")
 	list := flag.Bool("list", false, "print the list of available resolvers for the enabled filters")
@@ -225,9 +225,6 @@ func ConfigLoad(proxy *Proxy, svcFlag *string) error {
 
 	flag.Parse()
 
-	if *svcFlag == "stop" || *svcFlag == "uninstall" {
-		return nil
-	}
 	if *version {
 		fmt.Println(AppVersion)
 		os.Exit(0)

--- a/dnscrypt-proxy/main.go
+++ b/dnscrypt-proxy/main.go
@@ -56,9 +56,6 @@ func main() {
 	}
 	app.proxy = NewProxy()
 	_ = ServiceManagerStartNotify()
-	if err := ConfigLoad(app.proxy, svcFlag); err != nil {
-		dlog.Fatal(err)
-	}
 	if len(*svcFlag) != 0 {
 		if svc == nil {
 			dlog.Fatal("Built-in service installation is not supported on this platform")
@@ -85,6 +82,9 @@ func main() {
 			dlog.Fatal(err)
 		}
 	} else {
+		if err := ConfigLoad(app.proxy); err != nil {
+			dlog.Fatal(err)
+		}
 		app.signalWatch()
 		app.appMain()
 	}
@@ -93,10 +93,15 @@ func main() {
 }
 
 func (app *App) Start(service service.Service) error {
-	if err := app.proxy.InitPluginsGlobals(); err != nil {
-		dlog.Fatal(err)
-	}
-	go app.appMain()
+	go func() {
+		if err := ConfigLoad(app.proxy); err != nil {
+			dlog.Fatal(err)
+		}
+		if err := app.proxy.InitPluginsGlobals(); err != nil {
+			dlog.Fatal(err)
+		}
+		app.appMain()
+	}()
 	return nil
 }
 


### PR DESCRIPTION
This is an attempt to fix the issue I mentioned in #976 - where the Windows service manager kills the service before it starts up, if it didn't initialize in time.

The recommendation of other people encountering this issue with kardianos/service is simply to make sure the `Start` method returns as soon as possible by doing all the init async: https://github.com/kardianos/service/issues/131

So that is what I am doing here. If there is a `svc` object (i.e. running as a service), then `ConfigLoad`  runs inside a goroutine in `Start` - the same one that previously only ran `appMain`. If there is no `svc` object, then the `ConfigLoad` just happens in the main thread before setting up the signal listener and calling `appMain`.

This does mean that the config is no longer loaded before the block that handles service control (`len(*svcFlag) != 0`). So if your config is broken it will now still install the service. My guess is that most users will install the service with a default or blessed config first (i.e. through package manager or installer), then if they want to customize their own config they will test it with `-check` or `-list` before restarting (or reinstalling), so this shouldn't impact most cases. I think this simplifies the code a bit because there no longer needs to be a check in the config loader to see what the command-line service arguments were.

I am currently running a test version of this on my Windows and it seems to work okay. I could compile one inside a Windows Subsystem for Linux, but it would probably be better if someone with a real Linux could test this in systemd. I can't see it causing any major problems, since any failure in the config file drops a `dlog.Fatal`, which does `os.Exit(255)`, and there is no PID file written until `appMain` is invoked anyway.
