### PR TITLE
move ConfigLoad into Start function when running as a service (take 2)

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -225,7 +225,7 @@ func findConfigFile(configFile *string) (string, error) {
 func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	foundConfigFile, err := findConfigFile(flags.ConfigFile)
 	if err != nil {
-		dlog.Fatalf("Unable to load the configuration file [%s] -- Maybe use the -config command-line switch?", flags.ConfigFile)
+		dlog.Fatalf("Unable to load the configuration file [%s] -- Maybe use the -config command-line switch?", *flags.ConfigFile)
 	}
 	config := newConfig()
 	md, err := toml.DecodeFile(foundConfigFile, &config)

--- a/dnscrypt-proxy/main.go
+++ b/dnscrypt-proxy/main.go
@@ -46,6 +46,29 @@ func main() {
 		WorkingDirectory: pwd,
 	}
 	svcFlag := flag.String("service", "", fmt.Sprintf("Control the system service: %q", service.ControlAction))
+	version := flag.Bool("version", false, "print current proxy version")
+	resolve := flag.String("resolve", "", "resolve a name using system libraries")
+	flags := ConfigFlags{}
+	flags.List = flag.Bool("list", false, "print the list of available resolvers for the enabled filters")
+	flags.ListAll = flag.Bool("list-all", false, "print the complete list of available resolvers, ignoring filters")
+	flags.JsonOutput = flag.Bool("json", false, "output list as JSON")
+	flags.Check = flag.Bool("check", false, "check the configuration file and exit")
+	flags.ConfigFile = flag.String("config", DefaultConfigFileName, "Path to the configuration file")
+	flags.Child = flag.Bool("child", false, "Invokes program as a child process")
+	flags.NetprobeTimeoutOverride = flag.Int("netprobe-timeout", 60, "Override the netprobe timeout")
+	flags.ShowCerts = flag.Bool("show-certs", false, "print DoH certificate chain hashes")
+
+	flag.Parse()
+
+	if *version {
+		fmt.Println(AppVersion)
+		os.Exit(0)
+	}
+	if resolve != nil && len(*resolve) > 0 {
+		Resolve(*resolve)
+		os.Exit(0)
+	}
+
 	app := &App{
 		quit: make(chan struct{}),
 	}
@@ -56,7 +79,7 @@ func main() {
 	}
 	app.proxy = NewProxy()
 	_ = ServiceManagerStartNotify()
-	if err := ConfigLoad(app.proxy, svcFlag); err != nil {
+	if err := ConfigLoad(app.proxy, &flags); err != nil {
 		dlog.Fatal(err)
 	}
 	if len(*svcFlag) != 0 {


### PR DESCRIPTION
This is a second attempt at fixing the problem detailed in #976 where loading the config can take too long and then Windows kills the service before it's started. The first attempt was in #991 but it had a flaw that it broke the `-service` argument.

Here is my new version. What I have done is moved the flags parsing out of `config.go` and into `main.go`. By doing the flags parsing on the top level, we are able to process all of the "fast" flags (e.g. `-version`) immediately, then exit.

I have added a new struct called `ConfigFlags` that saves all the pointers to the parsed flags that need to be used in `ConfigLoad`. If we are running as a service, we store a pointer to that struct on the `App`, then pass it into `ConfigLoad` during the `Start` function of the service. If we are not running as a service, then we just pass the pointer direct.

A different implementation that I considered was to store all of the flags directly into `App` from the outset. This way no matter where we are in the application, we should always be able to get the parsed flags. It also means there would be one source of truth for all the parsed flags, instead of having some of them parsed into `ConfigFlags` and other ones used directly in `main()`. The down-side is that it would create a circular dependency from `main.go` to `config.go` (to load the config) and back (to find the application flags type). That might be okay in Golang, but it feels a little odd to me. Still, I would be happy to refactor it to work this way if seems like a better option?

Either way, I definitely have tested the `-service` flag now and this does seem to work correctly. Apologies for the bug on the first PR.