### PR TITLE
set go.mod to unix endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 *               text=auto
 *.go            text        diff=golang
 *.bat           text        eol=crlf
+go.mod          text        eol=lf
 
 # Ensure test fixtures don't get mangled
 **/testdata/**  -text


### PR DESCRIPTION
Now that we have a gitattributes, I'd like to add `go.mod` to it, since running a `go build` on Windows causes this file to get re-written with different line endings.