### PR TITLE
plugin_block_name: also block cname

### DIFF
--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -120,6 +120,9 @@ func (proxy *Proxy) InitPluginsGlobals() error {
 	if len(proxy.nxLogFile) != 0 {
 		*responsePlugins = append(*responsePlugins, Plugin(new(PluginNxLog)))
 	}
+	if len(proxy.blockNameFile) != 0 {
+		*responsePlugins = append(*responsePlugins, Plugin(new(PluginBlockName)))
+	}
 	if len(proxy.blockIPFile) != 0 {
 		*responsePlugins = append(*responsePlugins, Plugin(new(PluginBlockIP)))
 	}


### PR DESCRIPTION
```
Currently, CNAME can be used to resolve blocked domain (Just CNAME an
allowed domain to a blocked one and the server often return both the
CNAME and the A or AAAA field if it exists).

This is a naive implementation that check if an answer exists, check
every CNAME field in it against the blacklist.
It stops on the first error or on the first blocked CNAME.
```

I am not proficient in Go which is why I do think this implementation is not that great. However, I think a reference might be helpful.

**Note:** As this PR adds PluginBlockName as a response plugin, it might make sense to avoid checking responses with NXDomain and other errors against the blacklist.

Provides a sample implementation and close #1067 