### PR TITLE
Allow for trailing comments in lists

### DIFF
--- a/dnscrypt-proxy/plugin_block_ip.go
+++ b/dnscrypt-proxy/plugin_block_ip.go
@@ -38,6 +38,9 @@ func (plugin *PluginBlockIP) Init(proxy *Proxy) error {
 	plugin.blockedPrefixes = iradix.New()
 	plugin.blockedIPs = make(map[string]interface{})
 	for lineNo, line := range strings.Split(string(bin), "\n") {
+                if strings.Contains(line, "#") {
+                        line = line[:strings.Index(line, "#")]
+                }
 		line = strings.TrimFunc(line, unicode.IsSpace)
 		if len(line) == 0 || strings.HasPrefix(line, "#") {
 			continue

--- a/dnscrypt-proxy/plugin_block_name.go
+++ b/dnscrypt-proxy/plugin_block_name.go
@@ -94,6 +94,9 @@ func (plugin *PluginBlockName) Init(proxy *Proxy) error {
 		patternMatcher:  NewPatternPatcher(),
 	}
 	for lineNo, line := range strings.Split(string(bin), "\n") {
+		if strings.Contains(line, "#") {
+			line = line[:strings.Index(line, "#")]
+		}
 		line = strings.TrimFunc(line, unicode.IsSpace)
 		if len(line) == 0 || strings.HasPrefix(line, "#") {
 			continue

--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -45,6 +45,9 @@ func (plugin *PluginCloak) Init(proxy *Proxy) error {
 	plugin.patternMatcher = NewPatternPatcher()
 	cloakedNames := make(map[string]*CloakedName)
 	for lineNo, line := range strings.Split(string(bin), "\n") {
+		if strings.Contains(line, "#") {
+			line = line[:strings.Index(line, "#")]
+		}
 		line = strings.TrimFunc(line, unicode.IsSpace)
 		if len(line) == 0 || strings.HasPrefix(line, "#") {
 			continue

--- a/dnscrypt-proxy/plugin_forward.go
+++ b/dnscrypt-proxy/plugin_forward.go
@@ -35,6 +35,9 @@ func (plugin *PluginForward) Init(proxy *Proxy) error {
 		return err
 	}
 	for lineNo, line := range strings.Split(string(bin), "\n") {
+		if strings.Contains(line, "#") {
+			line = line[:strings.Index(line, "#")]
+		}
 		line = strings.TrimFunc(line, unicode.IsSpace)
 		if len(line) == 0 || strings.HasPrefix(line, "#") {
 			continue

--- a/dnscrypt-proxy/plugin_whitelist_name.go
+++ b/dnscrypt-proxy/plugin_whitelist_name.go
@@ -37,6 +37,9 @@ func (plugin *PluginWhitelistName) Init(proxy *Proxy) error {
 	plugin.allWeeklyRanges = proxy.allWeeklyRanges
 	plugin.patternMatcher = NewPatternPatcher()
 	for lineNo, line := range strings.Split(string(bin), "\n") {
+		if strings.Contains(line, "#") {
+			line = line[:strings.Index(line, "#")]
+		}
 		line = strings.TrimFunc(line, unicode.IsSpace)
 		if len(line) == 0 || strings.HasPrefix(line, "#") {
 			continue


### PR DESCRIPTION
Feature addition for behavior similar to hosts file.
The hash (#) symbol and trailing characters are dropped.

Example line: www.example.com #comment
Current Behavior: Line is ignored.
Proposed Behavior: "www.example.com" is used.

Example line: #www.example.com #comment
Current Behavior: Line is ignored.
Proposed Behavior: Line is truncated to "" and ignored.

Potential hazards:
Will break users' current lists that rely on the hash symbol to invalidate lines.
Potential performance degradation when reading large lists.

Reference: #1158 