### PR TITLE
WIP: add openbsd pledge and unveil support

### DIFF
--- a/dnscrypt-proxy/sandbox.go
+++ b/dnscrypt-proxy/sandbox.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/facebookgo/pidfile"
+)
+
+// Determine the minimum set of privileges and files we need to access. We cannot expand our privileges
+// after this function is called. This is only enforced on openbsd, but serves as a specification and may
+// inform the creation of manual sandbox rules on other platforms.
+//
+// N.B. If you add any promises in this function also add them to the first Pledge call in main!
+func InitSandbox(config *Config, flags *ConfigFlags) {
+	// need to do this first before we start unveiling things to get access to directories
+	execPath, err := exec.LookPath(os.Args[0])
+	if err == nil {
+		path, err := filepath.Abs(execPath)
+		if err == nil {
+			execPath = path
+		} else {
+			execPath = ""
+		}
+	} else {
+		execPath = ""
+	}
+
+	// minimum promises needed to function
+	// N.B. If you add any promises in this function also add them to the first Pledge call
+	//      in main!
+	promises := "cpath fattr inet rpath stdio wpath"
+
+	Unveil("/dev/random", "r")
+	Unveil("/dev/urandom", "r")
+	Unveil("/etc/ssl/cert.pem", "r")
+
+	if !config.IgnoreSystemDNS {
+		promises += " dns"
+	}
+
+	if !config.OfflineMode {
+		for _, cfgSource := range config.SourcesConfig {
+			UnveilContainingDirectoryOf(cfgSource.CacheFile, "crw")
+		}
+	}
+
+	if config.UseSyslog {
+		promises += " unix"
+		Unveil("/dev/log", "w")
+	} else if config.LogFile != nil {
+		Unveil(*config.LogFile, "cw")
+	}
+
+	if *flags.Check || *flags.List || *flags.ListAll {
+		PledgePromises(promises)
+		return
+	}
+
+	if len(config.UserName) > 0 && !*flags.Child {
+		if len(execPath) > 0 {
+			Unveil(execPath, "rx")
+		}
+		Unveil("/etc/passwd", "r")
+		PledgePromises(promises + " exec id")
+		return
+	}
+
+	if pidFilePath := pidfile.GetPidfilePath(); len(pidFilePath) > 1 {
+		// doesn't work because of os.MkdirAll
+		Unveil(pidFilePath, "cw")
+	}
+
+	if *flags.ShowCerts {
+		PledgePromises(promises)
+		return
+	}
+
+	Unveil(execPath, "r")
+
+	// All these logs don't work because of os.MkdirAll
+
+	Unveil(config.LocalDoH.CertFile, "r")
+	Unveil(config.LocalDoH.CertKeyFile, "r")
+
+	UnveilContainingDirectoryOf(config.QueryLog.File, "cw")
+
+	UnveilContainingDirectoryOf(config.NxLog.File, "cw")
+
+	Unveil(config.BlockName.File, "r")
+	UnveilContainingDirectoryOf(config.BlockName.LogFile, "cw")
+
+	Unveil(config.WhitelistName.File, "r")
+	UnveilContainingDirectoryOf(config.WhitelistName.LogFile, "cw")
+
+	Unveil(config.BlockIP.File, "r")
+	UnveilContainingDirectoryOf(config.BlockIP.LogFile, "cw")
+
+	Unveil(config.ForwardFile, "r")
+
+	Unveil(config.CloakFile, "r")
+
+	PledgePromises(promises)
+}

--- a/dnscrypt-proxy/sandbox_openbsd.go
+++ b/dnscrypt-proxy/sandbox_openbsd.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/jedisct1/dlog"
+)
+
+var (
+	workingDir = ""
+)
+
+func PledgePromises(promises string) {
+	dlog.Debugf("Pledging [%s]", promises)
+	err := unix.PledgePromises(promises)
+	if err != nil {
+		dlog.Fatalf("Failed to pledge [%s]: [%s]", promises, err)
+	}
+}
+
+func UnveilContainingDirectoryOf(path string, flags string) {
+	if len(path) > 0 {
+		saveWorkingDir()
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(workingDir, path)
+		}
+		Unveil(filepath.Dir(path), flags)
+	}
+}
+
+func Unveil(path string, flags string) {
+	if len(path) > 0 {
+		saveWorkingDir()
+		dlog.Debugf("Unveiling [%s] for [%s] access", path, flags)
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(workingDir, path)
+		}
+		err := unix.Unveil(path, flags)
+		if err != nil {
+			dlog.Fatalf("Failed to unveil [%s] for [%s] access: [%s]", path, flags, err)
+		}
+	}
+}
+
+func UnveilBlock() {
+	dlog.Debug("Blocking further unveil calls")
+	err := unix.UnveilBlock()
+	if err != nil {
+		dlog.Fatalf("UnveilBlock failed: [%s]", err)
+	}
+}
+
+// stash the working dir because once we start unveiling it becomes difficult to access it
+func saveWorkingDir() {
+	if len(workingDir) == 0 {
+		wd, err := os.Getwd()
+		if err != nil {
+			dlog.Fatalf("Unable to get the current working directory: [%s]", err)
+		}
+		workingDir = wd
+	}
+}

--- a/dnscrypt-proxy/sandbox_others.go
+++ b/dnscrypt-proxy/sandbox_others.go
@@ -1,0 +1,46 @@
+// +build !openbsd
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/jedisct1/dlog"
+)
+
+func PledgePromises(promises string) {
+	dlog.Debugf("Pledging [%s]", promises)
+}
+
+func UnveilContainingDirectoryOf(path string, flags string) {
+	if len(path) > 0 {
+		if !filepath.IsAbs(path) {
+			wd, err := os.Getwd()
+			if err != nil {
+				dlog.Warnf("Unable to get the current working directory: [%s]", err)
+				return
+			}
+			path = filepath.Join(wd, path)
+		}
+		Unveil(path, flags)
+	}
+}
+
+func Unveil(path string, flags string) {
+	if len(path) > 0 {
+		if !filepath.IsAbs(path) {
+			wd, err := os.Getwd()
+			if err != nil {
+				dlog.Warnf("Unable to get the current working directory: [%s]", err)
+				return
+			}
+			path = filepath.Join(wd, path)
+		}
+		dlog.Debugf("Unveiling [%s] for [%s] access", path, flags)
+	}
+}
+
+func UnveilBlock() {
+	dlog.Debug("Blocking further unveil calls")
+}


### PR DESCRIPTION
I've been tinkering with adding both pledge and unveil to dnscrypt-proxy.
It's not working completely, but I thought I would share my progress.

This currently requires a patch to the openbsd kernel because it refuses
to allow the kern.somaxconn sysctl which go looks up when it listens on
a tcp socket[1][2][3].

This breaks non-main log files and pid files as well, because
os.MkdirAll gets confused when unveil is used. I'm not sure how to
resolve this.

[1] https://golang.org/src/net/sock_posix.go#L57
[2] https://golang.org/src/net/net.go#L373
[3] https://golang.org/src/net/sock_bsd.go#L27

OpenBSD kernel patch:

```
diff --git sys/kern/kern_pledge.c sys/kern/kern_pledge.c
index 9f436df4893..8d1203198ed 100644
--- sys/kern/kern_pledge.c
+++ sys/kern/kern_pledge.c
@@ -904,6 +904,12 @@ pledge_sysctl(struct proc *p, int miblen, int *mib, void *new)
                        return (0);
        }

+       if ((p->p_p->ps_pledge & PLEDGE_INET)) {
+               if (miblen == 2 &&              /* kern.somaxconn */
+                   mib[0] == CTL_KERN && mib[1] == KERN_SOMAXCONN)
+                       return (0);
+       }
+
        if ((p->p_p->ps_pledge & (PLEDGE_ROUTE | PLEDGE_INET | PLEDGE_DNS))) {
                if (miblen == 6 &&              /* getifaddrs() */
                    mib[0] == CTL_NET && mib[1] == PF_ROUTE &&
```