### PR TITLE
Implement pN load balancing strategy

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -352,17 +352,22 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	switch strings.ToLower(config.LBStrategy) {
 	case "":
 		// default
-	case "p2":
-		lbStrategy = LBStrategyP2
 	case "ph":
 		lbStrategy = LBStrategyPH
 	case "fastest":
 	case "first":
-		lbStrategy = LBStrategyFirst
+		lbStrategy = LBStrategy(1)
 	case "random":
 		lbStrategy = LBStrategyRandom
+
 	default:
-		dlog.Warnf("Unknown load balancing strategy: [%s]", config.LBStrategy)
+		n, err := strconv.ParseUint(strings.TrimPrefix(config.LBStrategy, "p"), 10, 64)
+
+		if err == nil && n >= 1 {
+			lbStrategy = LBStrategy(n)
+		} else {
+			dlog.Warnf("Unknown load balancing strategy: [%s]", config.LBStrategy)
+		}
 	}
 	proxy.serversInfo.lbStrategy = lbStrategy
 	proxy.serversInfo.lbEstimator = config.LBEstimator

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -124,6 +124,7 @@ keepalive = 30
 
 
 ## Load-balancing strategy: 'p2' (default), 'ph', 'first' or 'random'
+## Use pN where N is a positive number to choose between N first fastest servers.
 
 # lb_strategy = 'p2'
 


### PR DESCRIPTION
### Motivation

This PR implements pN load balancing strategy, which allows users to choose
between speed and privacy more precisely.

For example my default server list contains 80 entries. As a user I want to be able
to choose from 10 fastest servers instead of querying one of 40 servers, as some
of them have latencies over 400ms.

This now can be accomplished with `lb_strategy = 'p10'` line in config file.


### Backward Compatibility 
This change does not break older configuration files because 'p2' still means that dnscrypt will try to choose between 2 fastest resolvers.