### PR TITLE
A few tiny doc fixes

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -192,12 +192,12 @@ cert_refresh_delay = 240
 ## They will never be used if lists have already been cached, and if stamps
 ## don't include host names without IP addresses.
 ## They will not be used if the configured system DNS works.
-## Resolver supporting DNSSEC are recommended.
+## Resolvers supporting DNSSEC are recommended.
 ##
 ## People in China may need to use 114.114.114.114:53 here.
 ## Other popular options include 8.8.8.8 and 1.1.1.1.
 ##
-## If more than one resolver are specified, they will be tried in sequence.
+## If more than one resolver is specified, they will be tried in sequence.
 
 fallback_resolvers = ['9.9.9.9:53', '8.8.8.8:53']
 
@@ -393,7 +393,7 @@ cache_neg_max_ttl = 600
 [query_log]
 
   ## Path to the query log file (absolute, or relative to the same directory as the config file)
-  ## Non non-Windows systems, can be /dev/stdout to log to the standard output (and set log_files_max_size to 0)
+  ## On non-Windows systems, can be /dev/stdout to log to the standard output (and set log_files_max_size to 0)
 
   # file = 'query.log'
 

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -200,7 +200,6 @@ func parseBlockedQueryResponse(blockedResponse string, pluginsGlobals *PluginsGl
 		if (*pluginsGlobals).respondWithIPv6 == nil {
 			(*pluginsGlobals).respondWithIPv6 = (*pluginsGlobals).respondWithIPv4
 		}
-
 	} else {
 		switch blockedResponse {
 		case "refused":

--- a/dnscrypt-proxy/sources_test.go
+++ b/dnscrypt-proxy/sources_test.go
@@ -33,8 +33,8 @@ const (
 	TestStateExpired                           // modification time of files set in distant past (cache only)
 	TestStatePartial                           // incomplete files
 	TestStatePartialSig                        // incomplete .minisig
-	TestStateMissing                           // non-existant files
-	TestStateMissingSig                        // non-existant .minisig
+	TestStateMissing                           // non-existent files
+	TestStateMissingSig                        // non-existent .minisig
 	TestStateReadErr                           // I/O error on reading files (download only)
 	TestStateReadSigErr                        // I/O error on reading .minisig (download only)
 	TestStateOpenErr                           // I/O error on opening files


### PR DESCRIPTION
Just a few spelling and grammar tweaks.

Interesting one is "more than one resolver is" and "more than one resolver are", i confused myself looking at it, so i did a search 🤦‍♀   https://www.grammarphobia.com/blog/2007/12/can-more-than-one-be-singular.html