### PR TITLE
Respect proxy.mainProto in forward plugin

### DIFF
--- a/dnscrypt-proxy/plugin_forward.go
+++ b/dnscrypt-proxy/plugin_forward.go
@@ -14,7 +14,6 @@ import (
 type PluginForwardEntry struct {
 	domain  string
 	servers []string
-	proto   string
 }
 
 type PluginForward struct {
@@ -62,7 +61,6 @@ func (plugin *PluginForward) Init(proxy *Proxy) error {
 		plugin.forwardMap = append(plugin.forwardMap, PluginForwardEntry{
 			domain:  domain,
 			servers: servers,
-			proto:   proxy.mainProto,
 		})
 	}
 	return nil
@@ -80,7 +78,6 @@ func (plugin *PluginForward) Eval(pluginsState *PluginsState, msg *dns.Msg) erro
 	qName := pluginsState.qName
 	qNameLen := len(qName)
 	var servers []string
-	var proto string
 	for _, candidate := range plugin.forwardMap {
 		candidateLen := len(candidate.domain)
 		if candidateLen > qNameLen {
@@ -88,7 +85,6 @@ func (plugin *PluginForward) Eval(pluginsState *PluginsState, msg *dns.Msg) erro
 		}
 		if qName[qNameLen-candidateLen:] == candidate.domain && (candidateLen == qNameLen || (qName[qNameLen-candidateLen-1] == '.')) {
 			servers = candidate.servers
-			proto = candidate.proto
 			break
 		}
 	}
@@ -97,7 +93,7 @@ func (plugin *PluginForward) Eval(pluginsState *PluginsState, msg *dns.Msg) erro
 	}
 	server := servers[rand.Intn(len(servers))]
 	pluginsState.serverName = server
-	client := dns.Client{Net: proto}
+	client := dns.Client{Net: pluginsState.serverProto}
 	respMsg, _, err := client.Exchange(msg, server)
 	if err != nil {
 		return err

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -86,6 +86,7 @@ type PluginsState struct {
 	cacheHit                         bool
 	returnCode                       PluginsReturnCode
 	serverName                       string
+	serverProto                      string
 }
 
 func (proxy *Proxy) InitPluginsGlobals() error {
@@ -222,7 +223,7 @@ type Plugin interface {
 	Eval(pluginsState *PluginsState, msg *dns.Msg) error
 }
 
-func NewPluginsState(proxy *Proxy, clientProto string, clientAddr *net.Addr, start time.Time) PluginsState {
+func NewPluginsState(proxy *Proxy, clientProto string, clientAddr *net.Addr, serverProto string, start time.Time) PluginsState {
 	return PluginsState{
 		action:                           PluginsActionContinue,
 		returnCode:                       PluginsReturnCodePass,
@@ -238,6 +239,7 @@ func NewPluginsState(proxy *Proxy, clientProto string, clientAddr *net.Addr, sta
 		questionMsg:                      nil,
 		qName:                            "",
 		serverName:                       "-",
+		serverProto:                      serverProto,
 		requestStart:                     start,
 		maxUnencryptedUDPSafePayloadSize: MaxDNSUDPSafePacketSize,
 		sessionData:                      make(map[string]interface{}),

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -443,7 +443,7 @@ func (proxy *Proxy) processIncomingQuery(clientProto string, serverProto string,
 	if len(query) < MinDNSPacketSize {
 		return
 	}
-	pluginsState := NewPluginsState(proxy, clientProto, clientAddr, start)
+	pluginsState := NewPluginsState(proxy, clientProto, clientAddr, serverProto, start)
 	serverName := "-"
 	needsEDNS0Padding := false
 	serverInfo := proxy.serversInfo.getOne()
@@ -543,12 +543,6 @@ func (proxy *Proxy) processIncomingQuery(clientProto string, serverProto string,
 			}
 			if response == nil {
 				response = serverResponse
-			}
-			if err != nil {
-				pluginsState.returnCode = PluginsReturnCodeNetworkError
-				pluginsState.ApplyLoggingPlugins(&proxy.pluginsGlobals)
-				serverInfo.noticeFailure(proxy)
-				return
 			}
 			if len(response) >= MinDNSPacketSize {
 				SetTransactionID(response, tid)


### PR DESCRIPTION
We have a problem very similar to the one described in http://lists.thekelleys.org.uk/pipermail/dnsmasq-discuss/2008q2/002103.html
We cannot use UDP for the upstream servers and we were planning on using dnsmasq but as described later in that thread, dnsmasq would send UDP clients as UDP to the upstreams and there is no way to force it to do TCP to the upstreams when the client uses UDP.

We can achieve similar functionality with `dnscrypt-proxy` with a config like the following:

```
      listen_addresses = ['127.0.0.1:53']
      offline_mode = true
      force_tcp = true
      ipv4_servers = true
      ipv6_servers = false
      block_ipv6 = true
      timeout = 5000
      keepalive = 30
      cache = false
      forwarding_rules = 'forwarding-rules.txt'
      log_file = '/dev/stdout'
      use_syslog = false
      log_level=0

      [query_log]
      file = '/dev/stdout'
      format = 'tsv'
      ignored_qtypes = ['DNSKEY', 'NS']
```

The current problem as it exist in `dnscrypt-proxy` right now is that the forwarding plugin does not respect the `force_tcp = true` option. This PR addresses that problem.

I was thinking to change the format of `forwarding-rules.txt` to be `domain IPs proto` instead of just `domain IPs`. I think that would work equally well but seems like it might be overkill if we already have the `force_tcp` option.

Please let me know what you think and I can add unit tests and stuff like this if possible.