### PR TITLE
Change URL of Block Spotify ads

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -120,7 +120,7 @@ https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt
 # https://raw.githubusercontent.com/anudeepND/blacklist/master/CoinMiner.txt
 
 # Block Spotify ads
-# https://raw.githubusercontent.com/CHEF-KOCH/Spotify-Ad-free/master/filter/Spotify-HOSTS.txt
+# https://raw.githubusercontent.com/CHEF-KOCH/Spotify-Ad-free/master/filters/Spotify-HOSTS.txt
 
 # Energized Ultimate
 # https://raw.githubusercontent.com/EnergizedProtection/block/master/ultimate/formats/domains.txt


### PR DESCRIPTION
The url of the Spotify-HOSTS.txt is changed. Path of "/filter/" is now "/filters/"