### PR TITLE
Adding support for additional root CAs for DoH TLS Auth

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -225,6 +225,7 @@ type TLSClientAuthCredsConfig struct {
 	ServerName string `toml:"server_name"`
 	ClientCert string `toml:"client_cert"`
 	ClientKey  string `toml:"client_key"`
+	RootCA     string `toml:"root_ca"`
 }
 
 type TLSClientAuthConfig struct {

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -647,7 +647,7 @@ fragments_blocked = ['cisco', 'cisco-ipv6', 'cisco-familyshield', 'cisco-familys
 [tls_client_auth]
 
 # creds = [
-#    { server_name='myserver', client_cert='client.crt', client_key='client.key' }
+#    { server_name='myserver', client_cert='client.crt', client_key='client.key', root_ca='ca.crt' }
 # ]
 
 

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -38,6 +38,7 @@ type ServerBugs struct {
 type DOHClientCreds struct {
 	clientCert string
 	clientKey  string
+	rootCA     string
 }
 
 type ServerInfo struct {

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha512"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -163,6 +164,15 @@ func (xTransport *XTransport) rebuildTransport() {
 		cert, err := tls.LoadX509KeyPair(clientCreds.clientCert, clientCreds.clientKey)
 		if err != nil {
 			dlog.Fatalf("Unable to use certificate [%v] (key: [%v]): %v", clientCreds.clientCert, clientCreds.clientKey, err)
+		}
+		if clientCreds.rootCA != "" {
+			caCert, err := ioutil.ReadFile(clientCreds.rootCA)
+			if err != nil {
+				dlog.Fatal(err)
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+			tlsClientConfig.RootCAs = caCertPool
 		}
 		tlsClientConfig.Certificates = []tls.Certificate{cert}
 	}


### PR DESCRIPTION
Adding the support for users to include their own Root CA certificate for cases where the Root CA isn't already included in the system's trusted bundle.

```
$ go test
PASS
  checks:  2009 passed  0 todo  0 failed	(total)
ok  	github.com/DNSCrypt/dnscrypt-proxy/dnscrypt-proxy	4.435s
```