### PR TITLE
Update EnergizedProtection URLs

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -117,13 +117,13 @@ https://hostfiles.frogeye.fr/firstparty-trackers.txt
 # https://raw.githubusercontent.com/CHEF-KOCH/Spotify-Ad-free/master/filters/Spotify-HOSTS.txt
 
 # Energized Ultimate
-# https://raw.githubusercontent.com/EnergizedProtection/block/master/ultimate/formats/domains.txt
+# https://block.energized.pro/ultimate/formats/hosts.txt
 
 # Energized BLU
-https://raw.githubusercontent.com/EnergizedProtection/block/master/blu/formats/domains.txt
+# https://block.energized.pro/blu/formats/hosts.txt
 
 # Energized Basic
-# https://raw.githubusercontent.com/EnergizedProtection/block/master/basic/formats/domains.txt
+# https://block.energized.pro/basic/formats/hosts.txt
 
 # Dynamic DNS services, sadly often used by malware
 # https://mirror1.malwaredomains.com/files/dynamic_dns.txt

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -120,7 +120,7 @@ https://hostfiles.frogeye.fr/firstparty-trackers.txt
 # https://block.energized.pro/ultimate/formats/hosts.txt
 
 # Energized BLU
-# https://block.energized.pro/blu/formats/hosts.txt
+https://block.energized.pro/blu/formats/hosts.txt
 
 # Energized Basic
 # https://block.energized.pro/basic/formats/hosts.txt


### PR DESCRIPTION
EnergizedProtection url links have changed, it seems they had to delete them from github and moved them to their self hosted domain (block.energized.pro).