### PR TITLE
Update link to Spam404 rule

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -51,7 +51,7 @@ https://easylist-downloads.adblockplus.org/fanboy-social.txt
 https://pgl.yoyo.org/adservers/serverlist.php
 
 # Spam404
-https://raw.githubusercontent.com/Dawsey21/Lists/master/adblock-list.txt
+https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
 
 # CJX Annoyance List
 https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjxlist.txt


### PR DESCRIPTION
Though the old link is still available, the rule file has stop updating for a long while.