### PR TITLE
Minor update to GH Actions workflow

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,4 +1,21 @@
-on: push
+on:
+  push:
+    paths:
+      - "**.go"
+      - "go.*"
+      - "**/testdata/**"
+      - ".ci/**"
+      - ".git*"
+      - ".github/workflows/releases.yml"
+  pull_request:
+    paths:
+      - "**.go"
+      - "go.*"
+      - "**/testdata/**"
+      - ".ci/**"
+      - ".git*"
+      - ".github/workflows/releases.yml"
+  create:
 
 name: CI and optionally publish
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -15,7 +15,6 @@ on:
       - ".ci/**"
       - ".git*"
       - ".github/workflows/releases.yml"
-  create:
 
 name: CI and optionally publish
 


### PR DESCRIPTION
Not sure if it's intended that CI didn't run on pull requests, but I believe it's safe to do so since GitHub explicitly won't expose secrets to PRs from a fork.

I've used my earlier experiment as reference to filter the paths that will trigger CI for push and pull request events.