### PR TITLE
update domains-blacklist.conf

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -51,7 +51,7 @@ https://easylist-downloads.adblockplus.org/easylistchina.txt
 https://easylist-downloads.adblockplus.org/fanboy-social.txt
 
 # Peter Lowe's Ad and tracking server list
-https://pgl.yoyo.org/adservers/serverlist.php
+https://pgl.yoyo.org/adservers/serverlist.php?hostformat=nohtml
 
 # Spam404
 https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -26,17 +26,6 @@
 # Local additions
 file:domains-blacklist-local-additions.txt
 
-### The high sensitivity list has fewer false positives down to the low sensitivty list with more false positives.
-### (Refer: https://isc.sans.edu/suspicious_domains.html)
-# SANS Institute suspicious domains, HIGH sensitivity level
-https://isc.sans.edu/feeds/suspiciousdomains_High.txt
-
-# SANS Institute suspicious domains, MEDIUM sensitivity level
-# https://isc.sans.edu/feeds/suspiciousdomains_Medium.txt
-
-# SANS Institute suspicious domains, LOW sensitivity level (not recommended)
-# https://isc.sans.edu/feeds/suspiciousdomains_Low.txt
-
 # AdAway is an open source ad blocker for Android using the hosts file.
 https://raw.githubusercontent.com/AdAway/adaway.github.io/master/hosts.txt
 

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -35,9 +35,6 @@ https://mirror1.malwaredomains.com/files/justdomains
 # Malware Domain List
 https://www.malwaredomainlist.com/hostslist/hosts.txt
 
-# Adblock Warning Removal List
-https://easylist-downloads.adblockplus.org/antiadblockfilters.txt
-
 # EasyList
 https://easylist-downloads.adblockplus.org/easylist_noelemhide.txt
 
@@ -47,20 +44,11 @@ https://easylist-downloads.adblockplus.org/easylistchina.txt
 # RU AdList
 # https://easylist-downloads.adblockplus.org/advblock.txt
 
-# Fanboy's Social Blocking List
-https://easylist-downloads.adblockplus.org/fanboy-social.txt
-
 # Peter Lowe's Ad and tracking server list
 https://pgl.yoyo.org/adservers/serverlist.php?hostformat=nohtml
 
 # Spam404
 https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
-
-# CJX Annoyance List
-https://raw.githubusercontent.com/cjx82630/cjxlist/master/cjxlist.txt
-
-# EU: Prebake - Filter Obtrusive Cookie Notices
-https://raw.githubusercontent.com/liamja/Prebake/master/obtrusive.txt
 
 # Malvertising filter list by Disconnect
 https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -48,28 +48,28 @@ https://easylist-downloads.adblockplus.org/easylistchina.txt
 https://pgl.yoyo.org/adservers/serverlist.php?hostformat=nohtml
 
 # Spam404
-https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
+# https://raw.githubusercontent.com/Spam404/lists/master/main-blacklist.txt
 
 # Malvertising filter list by Disconnect
-https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt
+# https://s3.amazonaws.com/lists.disconnect.me/simple_malvertising.txt
 
 # Ads filter list by Disconnect
-https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
+# https://s3.amazonaws.com/lists.disconnect.me/simple_ad.txt
 
 # Basic tracking list by Disconnect
-https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
+# https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
 
 # Sysctl list (ads)
 http://sysctl.org/cameleon/hosts
 
 # KAD host file (fraud/adware) without controversies
-https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts_without_controversies.txt
+# https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts_without_controversies.txt
 
 # BarbBlock list (spurious and invalid DMCA takedowns)
 https://ssl.bblck.me/blacklists/domain-list.txt
 
 # Dan Pollock's hosts list
-https://someonewhocares.org/hosts/hosts
+# https://someonewhocares.org/hosts/hosts
 
 # NoTracking's list - blocking ads, trackers and other online garbage
 https://raw.githubusercontent.com/notracking/hosts-blocklists/master/dnscrypt-proxy/dnscrypt-proxy.blacklist.txt
@@ -78,7 +78,7 @@ https://raw.githubusercontent.com/notracking/hosts-blocklists/master/dnscrypt-pr
 https://raw.githubusercontent.com/nextdns/cname-cloaking-blocklist/master/domains
 
 # AdGuard Simplified Domain Names filter
-https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt
+# https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt
 
 # Geoffrey Frogeye's block list of first-party trackers - https://hostfiles.frogeye.fr/
 https://hostfiles.frogeye.fr/firstparty-trackers.txt


### PR DESCRIPTION
When I checked out the new **SANS Institute suspicious domains** lists I noticed that they are not available anymore, which led me to also look at some other sources.

It turns out that many of the lists enabled by default are already included in the Energized Blu list (that is also enabled by default).

Also some of the lists consist almost exclusively of rules for removing elements or paths like `/ads`, but barely contain any domains, therefore I also removed them.

I'm also not sure if easylist china should be enabled by default, but I don't know the user base.

This is unrelated to the pull request, but I found a big collection of filter lists here https://firebog.net/ which might be useful
