### PR TITLE
sources_test: set bit 16 of the port instead of adding zeros

### DIFF
--- a/dnscrypt-proxy/sources_test.go
+++ b/dnscrypt-proxy/sources_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -300,6 +301,7 @@ func prepSourceTestDownload(t *testing.T, d *SourceTestData, e *SourceTestExpect
 	}
 	for _, state := range downloadTest {
 		path := "/" + strconv.FormatUint(uint64(state), 10) + "/" + source
+		serverURL := d.server.URL
 		switch state {
 		case TestStateMissing, TestStateMissingSig:
 			e.err = "404 Not Found"
@@ -308,16 +310,20 @@ func prepSourceTestDownload(t *testing.T, d *SourceTestData, e *SourceTestExpect
 		case TestStateReadErr, TestStateReadSigErr:
 			e.err = "unexpected EOF"
 		case TestStateOpenErr, TestStateOpenSigErr:
-			path = "00000" + path // high numeric port should be parsed but then fail to connect
+			if u, err := url.Parse(serverURL + path); err == nil {
+				host, port := ExtractHostAndPort(u.Host, -1)
+				u.Host = fmt.Sprintf("%s:%d", host, port|0x10000)
+				serverURL = u.String()
+			}
 			// Win10 treats an invalid port as part of the hostname, then tries DNS lookup and magic http->https upgrades simultaneously
 			e.err = "invalid port|no such host|too many colons in address"
 		case TestStatePathErr:
 			path = "..." + path // non-numeric port fails URL parsing
 		}
-		if u, err := url.Parse(d.server.URL + path); err == nil {
+		if u, err := url.Parse(serverURL + path); err == nil {
 			e.Source.urls = append(e.Source.urls, u)
 		}
-		e.urls = append(e.urls, d.server.URL+path)
+		e.urls = append(e.urls, serverURL+path)
 		if e.success {
 			continue
 		}


### PR DESCRIPTION
An attempt at fixing the tests on Windows 10 with 32 bit builds.

/cc @welwood08 @lifenjoiner 