### PR TITLE
Disable Sysctl list and AdAway, introduce GameIndustry.eu; Remove Chinese IT companies' top domain from whitelist.

### DIFF
--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -27,7 +27,7 @@
 file:domains-blacklist-local-additions.txt
 
 # AdAway is an open source ad blocker for Android using the hosts file.
-https://raw.githubusercontent.com/AdAway/adaway.github.io/master/hosts.txt
+# https://raw.githubusercontent.com/AdAway/adaway.github.io/master/hosts.txt
 
 # Malware domains
 https://mirror1.malwaredomains.com/files/justdomains

--- a/utils/generate-domains-blacklists/domains-blacklist.conf
+++ b/utils/generate-domains-blacklists/domains-blacklist.conf
@@ -60,7 +60,7 @@ https://pgl.yoyo.org/adservers/serverlist.php?hostformat=nohtml
 # https://s3.amazonaws.com/lists.disconnect.me/simple_tracking.txt
 
 # Sysctl list (ads)
-http://sysctl.org/cameleon/hosts
+# http://sysctl.org/cameleon/hosts
 
 # KAD host file (fraud/adware) without controversies
 # https://raw.githubusercontent.com/PolishFiltersTeam/KADhosts/master/KADhosts_without_controversies.txt
@@ -161,3 +161,6 @@ https://dbl.oisd.nl/
 
 # Block spying and tracking on Windows 
 # https://raw.githubusercontent.com/crazy-max/WindowsSpyBlocker/master/data/dnscrypt/spy.txt
+
+# GameIndustry.eu - Block spyware, advertising, analytics, tracking in games and associated clients
+# https://www.gameindustry.eu/files/hosts.txt


### PR DESCRIPTION
* The host file from http://sysctl.org/cameleon is no longer updated, therefore it should be disabled.

* Introduce a new rule maintained by GameIndustry.eu. I only pick the rule sets that NextDNS provides to its customers of their choice, as these rule sets are generally seen as stable and reliable.
However I don't play game so much, there is no way to perform a fully test on my side. There is no FP detected during the couple of days while I using this rule set. And I've gone through the entire contents of the host file in roughly, the entries all seem reasonable to me.

~~It doesn't take long for jedisct1 add baidu.com, and 163.com into whitelist after I introduced AdAway's ruleset into the configuration file, so I guess that the AdAway rule set must have presented a lot of false positives.
However, these Chinese IT companies are notorious for their extensive user-tracking tactics. Whitelist their top domain may not a good idea.
My suggestion is to simply disable the ruleset present FP, and let software like ABP or AdGuard do the most elaborate work. - Blocking on the DNS level has its limitations.~~