### PR TITLE
Delete top domains conflict with Windows spy blocking rules

### DIFF
--- a/utils/generate-domains-blacklists/domains-whitelist.txt
+++ b/utils/generate-domains-blacklists/domains-whitelist.txt
@@ -39,8 +39,6 @@ localdomain
 login.microsoftonline.com
 login.yahoo.com
 mdidesign.ca
-microsoft.com
-msedge.net
 msftconnecttest.com
 msftncsi.com
 nsatc.net
@@ -70,5 +68,4 @@ urldefense.proofpoint.com
 userbenchmark.com
 vk.com
 vlab.pp.ru
-windows.net
 youtu.be


### PR DESCRIPTION
The Windows spy blocking ruleset doesn't cause any trouble on my side. Thus I would like this ruleset to never be shadowed by the whitelist.