### PR TITLE
Add note on how to enable debug logging

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -136,6 +136,7 @@ keepalive = 30
 
 
 ## Log level (0-6, default: 2 - 0 is very verbose, 6 only contains fatal errors)
+## Note: for log level 0 (debug), the environment variable DEBUG must also be set.
 
 # log_level = 2
 


### PR DESCRIPTION
I just spent some time trying to understand why `log_level=0` didn't get me any debug output in the log.