### PR TITLE
Issue #1380: Reenable HTTP/2 for local DoH

### DIFF
--- a/.ci/ci-test.sh
+++ b/.ci/ci-test.sh
@@ -82,7 +82,7 @@ t || dig -p${DNS_PORT} tracker.xdebian.org @127.0.0.1 | grep -Fq 'locally blocke
 t || dig -p${DNS_PORT} tracker.debian.org @127.0.0.1 | grep -Fqv 'locally blocked' || fail
 
 section
-t || curl --insecure -siL https://127.0.0.1:${HTTP_PORT}/ | grep -Fq '404 Not Found' || fail
+t || curl --insecure -siL https://127.0.0.1:${HTTP_PORT}/ | grep -Fq 'HTTP/2 404' || fail
 t || curl --insecure -sL https://127.0.0.1:${HTTP_PORT}/dns-query | grep -Fq 'dnscrypt-proxy local DoH server' || fail
 t ||
     echo yv4BAAABAAAAAAABAAACAAEAACkQAAAAgAAAAA== | base64 -d |

--- a/dnscrypt-proxy/local-doh.go
+++ b/dnscrypt-proxy/local-doh.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"io"
 	"io/ioutil"
 	"net"
@@ -86,11 +85,9 @@ func (proxy *Proxy) localDoHListener(acceptPc *net.TCPListener) {
 	if len(proxy.localDoHCertFile) == 0 || len(proxy.localDoHCertKeyFile) == 0 {
 		dlog.Fatal("A certificate and a key are required to start a local DoH service")
 	}
-	noh2 := make(map[string]func(*http.Server, *tls.Conn, http.Handler))
 	httpServer := &http.Server{
 		ReadTimeout:  proxy.timeout,
 		WriteTimeout: proxy.timeout,
-		TLSNextProto: noh2,
 		Handler:      localDoHHandler{proxy: proxy},
 	}
 	httpServer.SetKeepAlivesEnabled(true)


### PR DESCRIPTION
As per #1380, this patch just reenables HTTP/2 for local DoH.

This is verified in firefox about:networking.

I tested this with about 2 hours of browsing on 6 devices on a Raspberry pi 4b. No problems so far, even with Cloudflare ESNI enabled sites such as medium.com, cloudflare, reddit, hackernews, random blogs, bbc, etc...