### PR TITLE
Update broken_implementations list with updated Quad9 v3 names

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -641,7 +641,7 @@ cache_neg_max_ttl = 600
 # The list below enables workarounds to make non-relayed usage more reliable
 # until the servers are fixed.
 
-fragments_blocked = ['cisco', 'cisco-ipv6', 'cisco-familyshield', 'cisco-familyshield-ipv6', 'quad9-dnscrypt-ip4-filter-alt', 'quad9-dnscrypt-ip4-filter-pri', 'quad9-dnscrypt-ip4-nofilter-alt', 'quad9-dnscrypt-ip4-nofilter-pri', 'quad9-dnscrypt-ip6-filter-alt', 'quad9-dnscrypt-ip6-filter-pri', 'quad9-dnscrypt-ip6-nofilter-alt', 'quad9-dnscrypt-ip6-nofilter-pri', 'cleanbrowsing-adult', 'cleanbrowsing-family-ipv6', 'cleanbrowsing-family', 'cleanbrowsing-security']
+fragments_blocked = ['cisco', 'cisco-ipv6', 'cisco-familyshield', 'cisco-familyshield-ipv6', 'quad9-dnscrypt-ip4-filter', 'quad9-dnscrypt-ip4-nofilter', 'quad9-dnscrypt-ip6-filter', 'quad9-dnscrypt-ip6-nofilter', 'cleanbrowsing-adult', 'cleanbrowsing-family-ipv6', 'cleanbrowsing-family', 'cleanbrowsing-security']
 
 
 


### PR DESCRIPTION
Due to the [name changes of Quad9 entries](https://github.com/DNSCrypt/dnscrypt-resolvers/pull/315) in the new v3 format, update the list of broken implementations with the new names.