### PR TITLE
initialize the log file before reporting config errors

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -294,7 +294,7 @@ func findConfigFile(configFile *string) (string, error) {
 func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	foundConfigFile, err := findConfigFile(flags.ConfigFile)
 	if err != nil {
-		dlog.Fatalf("Unable to load the configuration file [%s] -- Maybe use the -config command-line switch?", *flags.ConfigFile)
+		return fmt.Errorf("Unable to load the configuration file [%s] -- Maybe use the -config command-line switch?", *flags.ConfigFile)
 	}
 	config := newConfig()
 	md, err := toml.DecodeFile(foundConfigFile, &config)
@@ -347,7 +347,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	if len(config.FallbackResolvers) > 0 {
 		for _, resolver := range config.FallbackResolvers {
 			if err := isIPAndPort(resolver); err != nil {
-				dlog.Fatalf("Fallback resolver [%v]: %v", resolver, err)
+				return fmt.Errorf("Fallback resolver [%v]: %v", resolver, err)
 			}
 		}
 		proxy.xTransport.ignoreSystemDNS = config.IgnoreSystemDNS
@@ -359,7 +359,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	if len(config.HTTPProxyURL) > 0 {
 		httpProxyURL, err := url.Parse(config.HTTPProxyURL)
 		if err != nil {
-			dlog.Fatalf("Unable to parse the HTTP proxy URL [%v]", config.HTTPProxyURL)
+			return fmt.Errorf("Unable to parse the HTTP proxy URL [%v]", config.HTTPProxyURL)
 		}
 		proxy.xTransport.httpProxyFunction = http.ProxyURL(httpProxyURL)
 	}
@@ -367,11 +367,11 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	if len(config.Proxy) > 0 {
 		proxyDialerURL, err := url.Parse(config.Proxy)
 		if err != nil {
-			dlog.Fatalf("Unable to parse the proxy URL [%v]", config.Proxy)
+			return fmt.Errorf("Unable to parse the proxy URL [%v]", config.Proxy)
 		}
 		proxyDialer, err := netproxy.FromURL(proxyDialerURL, netproxy.Direct)
 		if err != nil {
-			dlog.Fatalf("Unable to use the proxy: [%v]", err)
+			return fmt.Errorf("Unable to use the proxy: [%v]", err)
 		}
 		proxy.xTransport.proxyDialer = &proxyDialer
 		proxy.mainProto = "tcp"
@@ -432,7 +432,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.listenAddresses = config.ListenAddresses
 	proxy.localDoHListenAddresses = config.LocalDoH.ListenAddresses
 	if len(config.LocalDoH.Path) > 0 && config.LocalDoH.Path[0] != '/' {
-		dlog.Fatalf("local DoH: [%s] cannot be a valid URL path. Read the documentation", config.LocalDoH.Path)
+		return fmt.Errorf("local DoH: [%s] cannot be a valid URL path. Read the documentation", config.LocalDoH.Path)
 	}
 	proxy.localDoHPath = config.LocalDoH.Path
 	proxy.localDoHCertFile = config.LocalDoH.CertFile
@@ -483,7 +483,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.nxLogFormat = config.NxLog.Format
 
 	if len(config.BlockName.File) > 0 && len(config.BlockNameLegacy.File) > 0 {
-		dlog.Fatal("Don't specify both [blocked_names] and [blacklist] sections - Update your config file.")
+		return errors.New("Don't specify both [blocked_names] and [blacklist] sections - Update your config file.")
 	}
 	if len(config.BlockNameLegacy.File) > 0 {
 		dlog.Notice("Use of [blacklist] is deprecated - Update your config file.")
@@ -504,7 +504,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.blockNameLogFile = config.BlockName.LogFile
 
 	if len(config.AllowedName.File) > 0 && len(config.WhitelistNameLegacy.File) > 0 {
-		dlog.Fatal("Don't specify both [whitelist] and [allowed_names] sections - Update your config file.")
+		return errors.New("Don't specify both [whitelist] and [allowed_names] sections - Update your config file.")
 	}
 	if len(config.WhitelistNameLegacy.File) > 0 {
 		dlog.Notice("Use of [whitelist] is deprecated - Update your config file.")
@@ -525,7 +525,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.whitelistNameLogFile = config.AllowedName.LogFile
 
 	if len(config.BlockIP.File) > 0 && len(config.BlockIPLegacy.File) > 0 {
-		dlog.Fatal("Don't specify both [blocked_ips] and [ip_blacklist] sections - Update your config file.")
+		return errors.New("Don't specify both [blocked_ips] and [ip_blacklist] sections - Update your config file.")
 	}
 	if len(config.BlockIPLegacy.File) > 0 {
 		dlog.Notice("Use of [ip_blacklist] is deprecated - Update your config file.")
@@ -565,7 +565,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.anonDirectCertFallback = config.AnonymizedDNS.DirectCertFallback
 
 	if config.DoHClientX509AuthLegacy.Creds != nil {
-		dlog.Fatal("[tls_client_auth] has been renamed to [doh_client_x509_auth] - Update your config file.")
+		return errors.New("[tls_client_auth] has been renamed to [doh_client_x509_auth] - Update your config file.")
 	}
 	configClientCreds := config.DoHClientX509Auth.Creds
 	creds := make(map[string]DOHClientCreds)
@@ -623,13 +623,13 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 			proxy.addLocalDoHListener(listenAddrStr)
 		}
 		if err := proxy.addSystemDListeners(); err != nil {
-			dlog.Fatal(err)
+			return err
 		}
 	}
 	// if 'userName' is set and we are the parent process drop privilege and exit
 	if len(proxy.userName) > 0 && !proxy.child {
 		proxy.dropPrivilege(proxy.userName, FileDescriptors)
-		dlog.Fatal("Dropping privileges is not supporting on this operating system. Unset `user_name` in the configuration file.")
+		return errors.New("Dropping privileges is not supporting on this operating system. Unset `user_name` in the configuration file.")
 	}
 	if !config.OfflineMode {
 		if err := config.loadSources(proxy); err != nil {
@@ -640,7 +640,9 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 		}
 	}
 	if *flags.List || *flags.ListAll {
-		config.printRegisteredServers(proxy, *flags.JSONOutput)
+		if err := config.printRegisteredServers(proxy, *flags.JSONOutput); err != nil {
+			return err
+		}
 		os.Exit(0)
 	}
 	if proxy.routes != nil && len(*proxy.routes) > 0 {
@@ -670,7 +672,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	return nil
 }
 
-func (config *Config) printRegisteredServers(proxy *Proxy, jsonOutput bool) {
+func (config *Config) printRegisteredServers(proxy *Proxy, jsonOutput bool) error {
 	var summary []ServerSummary
 	for _, registeredServer := range proxy.registeredServers {
 		addrStr, port := registeredServer.stamp.ServerAddrStr, stamps.DefaultPort
@@ -707,10 +709,11 @@ func (config *Config) printRegisteredServers(proxy *Proxy, jsonOutput bool) {
 	if jsonOutput {
 		jsonStr, err := json.MarshalIndent(summary, "", " ")
 		if err != nil {
-			dlog.Fatal(err)
+			return err
 		}
 		fmt.Print(string(jsonStr))
 	}
+	return nil
 }
 
 func (config *Config) loadSources(proxy *Proxy) error {
@@ -741,11 +744,11 @@ func (config *Config) loadSources(proxy *Proxy) error {
 			continue
 		}
 		if len(staticConfig.Stamp) == 0 {
-			dlog.Fatalf("Missing stamp for the static [%s] definition", serverName)
+			return fmt.Errorf("Missing stamp for the static [%s] definition", serverName)
 		}
 		stamp, err := stamps.NewServerStampFromString(staticConfig.Stamp)
 		if err != nil {
-			dlog.Fatalf("Stamp error for the static [%s] definition: [%v]", serverName, err)
+			return fmt.Errorf("Stamp error for the static [%s] definition: [%v]", serverName, err)
 		}
 		proxy.registeredServers = append(proxy.registeredServers, RegisteredServer{name: serverName, stamp: stamp})
 	}

--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -301,10 +301,6 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	if err != nil {
 		return err
 	}
-	undecoded := md.Undecoded()
-	if len(undecoded) > 0 {
-		return fmt.Errorf("Unsupported key in configuration file: [%s]", undecoded[0])
-	}
 	if err := cdFileDir(foundConfigFile); err != nil {
 		return err
 	}
@@ -326,6 +322,14 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 			dlog.SetFileDescriptor(os.NewFile(uintptr(3), "logFile"))
 		}
 	}
+	if !*flags.Child {
+		dlog.Noticef("dnscrypt-proxy %s", AppVersion)
+	}
+	undecoded := md.Undecoded()
+	if len(undecoded) > 0 {
+		return fmt.Errorf("Unsupported key in configuration file: [%s]", undecoded[0])
+	}
+
 	proxy.logMaxSize = config.LogMaxSize
 	proxy.logMaxAge = config.LogMaxAge
 	proxy.logMaxBackups = config.LogMaxBackups
@@ -608,9 +612,6 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 		netprobeAddress = config.FallbackResolvers[0]
 	}
 	proxy.showCerts = *flags.ShowCerts || len(os.Getenv("SHOW_CERTS")) > 0
-	if !proxy.child {
-		dlog.Noticef("dnscrypt-proxy %s", AppVersion)
-	}
 	if !*flags.Check && !*flags.ShowCerts && !*flags.List && !*flags.ListAll {
 		if err := NetProbe(netprobeAddress, netprobeTimeout); err != nil {
 			return err


### PR DESCRIPTION
Further to the discussion in #1413 here is change to the way we load the config file to first initialize the log file before reporting any errors in the config. This will hopefully make it more obvious to people who are running in an automated setup (i.e. Windows or systemd service) why something went wrong after an upgrade to an incompatible version, since normal output to stderr might otherwise get lost.

Here is the output of a manual test to show how it works:

```bash
$ ./dnscrypt-proxy.exe -config abc
[2020-07-26 20:48:35] [FATAL] Unable to load the configuration file [abc] -- Maybe use the -config command-line switch?
$ cat > abc <<EOF
log_file = "def"
unknown = "bad_config"
EOF
$ ./dnscrypt-proxy.exe -config abc
$ echo $?
255
$ cat def
[2020-07-26 20:48:48] [NOTICE] dnscrypt-proxy 2.0.44
[2020-07-26 20:48:48] [FATAL] Unsupported key in configuration file: [unknown]
```

Note that all errors returned during config will result in a fatal log due to code inside main.go (see https://github.com/alisonatwork/dnscrypt-proxy/blob/master/dnscrypt-proxy/main.go#L127) so even very aggressive log levels should still log this kind of failure to the log file or syslog.

To try make the behavior of all config errors resulting in a fatal log more clear to developers, I added a second commit which makes all of the fatal logs just return an error. There is an alternative option, which would be to replace all the "return error" lines with a fatal log. Personally I prefer returning an error, but I don't care too much either way, the main point here is to make all of them consistent.
