### PR TITLE
user-friendly comments - follow up to #1412

### DIFF
--- a/utils/generate-domains-blocklists/generate-domains-blocklist.py
+++ b/utils/generate-domains-blocklists/generate-domains-blocklist.py
@@ -290,7 +290,7 @@ argp.add_argument(
 argp.add_argument(
     "-w",
     "--whitelist",
-    help="Deprecated.  Please use -a or --allowlist",
+    help=argparse.SUPPRESS,
 )
 argp.add_argument(
     "-a",
@@ -322,7 +322,8 @@ args = argp.parse_args()
 
 whitelist = args.whitelist
 if whitelist:
-    print("Use of -w WHITELIST has been removed. Please use -a ALLOWLIST instead.")
+    print("The option to provide a set of names to exclude from the blocklist has been changed from -w to -a\r\n")
+    argp.print_help()
     exit(1)
 
 conf = args.config


### PR DESCRIPTION
Apologies it was such a long wait for a couple of small tweaks.

It turned out to be quite easy to suppress the -w so it doesn't show in the help statement.  I've tweaked the message as suggested as well.
This would leave it possible to run with -w  and not exit, as it does now (line 327).  Although I suspect it might be a bit late for that now... it'd be an easy update if you like that option though.
