### PR TITLE
Update example-dnscrypt-proxy.toml

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -134,7 +134,7 @@ keepalive = 30
 
 
 ## Load-balancing strategy: 'p2' (default), 'ph', 'pn', 'first' or 'random'
-## Use the 2, half, n, 1 or random number of all by latency.
+## Randomly choose 1 of the fastest 2, half, n, 1 or all live servers by latency.
 ## The response quality still depends on the server itself.
 
 # lb_strategy = 'p2'

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -133,7 +133,7 @@ keepalive = 30
 # blocked_query_response = 'refused'
 
 
-## Load-balancing strategy: 'p2' (default), 'ph', 'pn', 'first' or 'random'
+## Load-balancing strategy: 'p2' (default), 'ph', 'p<n>', 'first' or 'random'
 ## Randomly choose 1 of the fastest 2, half, n, 1 or all live servers by latency.
 ## The response quality still depends on the server itself.
 
@@ -147,7 +147,6 @@ keepalive = 30
 
 
 ## Log level (0-6, default: 2 - 0 is very verbose, 6 only contains fatal errors)
-## If you set it to 0 for debugging mode, environment variable `DEBUG` is needed.
 
 # log_level = 2
 

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -141,11 +141,13 @@ keepalive = 30
 
 ## Set to `true` to constantly try to estimate the latency of all the resolvers
 ## and adjust the load-balancing parameters accordingly, or to `false` to disable.
+## Default is `true` that makes 'p2' `lb_strategy` work well.
 
 # lb_estimator = true
 
 
 ## Log level (0-6, default: 2 - 0 is very verbose, 6 only contains fatal errors)
+## If you set it to 0 for debugging mode, environment variable `DEBUG` is needed.
 
 # log_level = 2
 

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -125,15 +125,17 @@ keepalive = 30
 # edns_client_subnet = ["0.0.0.0/0", "2001:db8::/32"]
 
 
-## Response for blocked queries.  Options are `refused`, `hinfo` (default) or
-## an IP response.  To give an IP response, use the format `a:<IPv4>,aaaa:<IPv6>`.
+## Response for blocked queries. Options are `refused`, `hinfo` (default) or
+## an IP response. To give an IP response, use the format `a:<IPv4>,aaaa:<IPv6>`.
 ## Using the `hinfo` option means that some responses will be lies.
 ## Unfortunately, the `hinfo` option appears to be required for Android 8+
 
 # blocked_query_response = 'refused'
 
 
-## Load-balancing strategy: 'p2' (default), 'ph', 'first' or 'random'
+## Load-balancing strategy: 'p2' (default), 'ph', 'pn', 'first' or 'random'
+## Use the 2, half, n, 1 or random number of all by latency.
+## The response quality still depends on the server itself.
 
 # lb_strategy = 'p2'
 


### PR DESCRIPTION
`lb_strategy` option 'pn' has been implemented, but not documented.