### PR TITLE
Change example forwarding rule to match recommended .home.arpa TLD

### DIFF
--- a/dnscrypt-proxy/example-forwarding-rules.txt
+++ b/dnscrypt-proxy/example-forwarding-rules.txt
@@ -13,10 +13,10 @@
 ## Blocking IPv6 may prevent local devices from being discovered.
 ## If this happens, set `block_ipv6` to `false` in the main config file.
 
-## Forward *.lan, *.local, *.home, *.internal and *.localdomain to 192.168.1.1
+## Forward *.lan, *.local, *.home.arpa, *.internal and *.localdomain to 192.168.1.1
 # lan             192.168.1.1
 # local           192.168.1.1
-# home            192.168.1.1
+# home.arpa       192.168.1.1
 # internal        192.168.1.1
 # localdomain     192.168.1.1
 


### PR DESCRIPTION
The ".home" TLD was proposed at one point, and while it's probably not going to actually ever get delegated it's not best practice to just start using your own TLD. The .home.arpa domain has been specifically set aside for use in home networks (RFC 8375) and is probably the better example to put here.