### PR TITLE
Add options to hide domain names and client IPs in the query log

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -168,9 +168,11 @@ type SourceConfig struct {
 }
 
 type QueryLogConfig struct {
-	File          string
-	Format        string
-	IgnoredQtypes []string `toml:"ignored_qtypes"`
+	File           string
+	Format         string
+	IgnoredQtypes  []string `toml:"ignored_qtypes"`
+	HideClientIP   bool     `toml:"hide_client_ip"`
+	HideDomainName bool     `toml:"hide_domain_name"`
 }
 
 type NxLogConfig struct {
@@ -490,6 +492,8 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.queryLogFile = config.QueryLog.File
 	proxy.queryLogFormat = config.QueryLog.Format
 	proxy.queryLogIgnoredQtypes = config.QueryLog.IgnoredQtypes
+	proxy.queryLogHideClientIP = config.QueryLog.HideClientIP
+	proxy.queryLogHideDomainName = config.QueryLog.HideDomainName
 
 	if len(config.NxLog.Format) == 0 {
 		config.NxLog.Format = "tsv"

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -432,6 +432,16 @@ cache_neg_max_ttl = 600
   # ignored_qtypes = ['DNSKEY', 'NS']
 
 
+  ## Do not log the clients' IP addresses.
+
+  # hide_client_ip = false
+
+
+  ## Do not log the queried domain names.
+
+  # hide_domain_name = false
+
+
 
 ############################################
 #        Suspicious queries logging        #

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -92,6 +92,8 @@ type Proxy struct {
 	pluginBlockUndelegated         bool
 	child                          bool
 	daemonize                      bool
+	queryLogHideClientIP           bool
+	queryLogHideDomainName         bool
 }
 
 func (proxy *Proxy) registerUDPListener(conn *net.UDPConn) {


### PR DESCRIPTION
This PR adds two new options to the query log plugin, `hide_client_ip` and `hide_domain_name`, that replace respectively the client IP address and the queried domain name with `***` in  the query log file.

My use case is that I like having the query log available to do some statistical analysis but I'd prefer not to have a permanent record of who looked for what.