### PR TITLE
register servers after loading statics

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -774,7 +774,6 @@ func (config *Config) loadSources(proxy *Proxy) error {
 			return err
 		}
 	}
-	proxy.updateRegisteredServers()
 	for name, config := range config.StaticsConfig {
 		if stamp, err := stamps.NewServerStampFromString(config.Stamp); err == nil {
 			if stamp.Proto == stamps.StampProtoTypeDNSCryptRelay || stamp.Proto == stamps.StampProtoTypeODoHRelay {
@@ -806,7 +805,7 @@ func (config *Config) loadSources(proxy *Proxy) error {
 	rand.Shuffle(len(proxy.registeredServers), func(i, j int) {
 		proxy.registeredServers[i], proxy.registeredServers[j] = proxy.registeredServers[j], proxy.registeredServers[i]
 	})
-
+	proxy.updateRegisteredServers()
 	return nil
 }
 


### PR DESCRIPTION
Statics were not registered correctly at launch time.  
Moves the first call to register servers until after the statics are loaded