### PR TITLE
Threadsafe update

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -352,6 +352,9 @@ func (proxy *Proxy) updateRegisteredServers() error {
 	for _, registeredServer := range proxy.registeredServers {
 		proxy.serversInfo.registerServer(registeredServer.name, registeredServer.stamp)
 	}
+	for _, registeredRelay := range proxy.registeredRelays {
+		proxy.serversInfo.registerRelay(registeredRelay.name, registeredRelay.stamp)
+	}
 	return nil
 }
 


### PR DESCRIPTION
@jedisct1 
First commit moves registeredRelays into serversInfo (analagous to registeredServers)
Second commit adds locks around each copy taken of registeredRelays in serversInfo.

Do you think this might cover it?
Happy for pointers or alternative solutions... 
This will need a careful code review - Is it bad form to start each function with a `defer serversInfo.Unlock()` to ensure as each function exits we never leave a lock in place?

I'm currently testing this with 3 server_names and a '*' in the routes 
