### PR TITLE
Support: Relay randomization

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -152,6 +152,7 @@ func newConfig() Config {
 		},
 		AnonymizedDNS: AnonymizedDNSConfig{
 			DirectCertFallback: true,
+			RelayRandomization: false,
 		},
 	}
 }
@@ -232,6 +233,7 @@ type AnonymizedDNSConfig struct {
 	Routes             []AnonymizedDNSRouteConfig `toml:"routes"`
 	SkipIncompatible   bool                       `toml:"skip_incompatible"`
 	DirectCertFallback bool                       `toml:"direct_cert_fallback"`
+	RelayRandomization bool                       `toml:"relay_randomization"`
 }
 
 type BrokenImplementationsConfig struct {
@@ -614,6 +616,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	}
 	proxy.skipAnonIncompatibleResolvers = config.AnonymizedDNS.SkipIncompatible
 	proxy.anonDirectCertFallback = config.AnonymizedDNS.DirectCertFallback
+	proxy.anonRelayRandomization = config.AnonymizedDNS.RelayRandomization
 
 	if config.DoHClientX509AuthLegacy.Creds != nil {
 		return errors.New("[tls_client_auth] has been renamed to [doh_client_x509_auth] - Update your config file")
@@ -732,6 +735,9 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 			} else {
 				dlog.Noticef("Anonymized DNS: routing everything via %v", via)
 			}
+		}
+		if proxy.anonRelayRandomization {
+			dlog.Noticef("Anonymized DNS: relay randomization turned on")
 		}
 	}
 	if *flags.Check {

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -778,7 +778,9 @@ skip_incompatible = false
 
 # direct_cert_fallback = false
 
-
+# If multiple relays are specified, one of them are randomly chosen when a query get issued.
+# Default value is false (non-randomized).
+# relay_randomization = true
 
 ###############################
 #            DNS64            #


### PR DESCRIPTION
Hello,

In the documentation, the following was mentioned as caveats.

> For each server, a random relay from the set is chosen when the proxy starts, and the same relay will be used until the proxy is restarted. Relay randomization and failover will be implemented in future versions.

https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Anonymized-DNS

I just implemented the relay randomization mentioned above (since I needed :-) ). The option of relay randomization can be enabled by making `relay_randomization` true in `dnscrypt-proxy.toml`.  If this is enabled, one relay server is randomly chosen from an array of relay candidates at each query issuance. 

If you are okay, please review and consider to merge this commit. Thanks a lot for this quite nice software!