### PR TITLE
Fix domain blocklist config example

### DIFF
--- a/utils/generate-domains-blocklist/domains-blocklist.conf
+++ b/utils/generate-domains-blocklist/domains-blocklist.conf
@@ -10,16 +10,16 @@
 #   you would like enabled uncommented.  Then run the script to build the        #
 #   dnscrypt-blocklist-domains.txt file:                                         #
 #                                                                                #
-#   $  generate-domains-blocklist.py > dnscrypt-blacklist-domains.txt            #
+#   $  generate-domains-blocklist.py -o dnscrypt-blocklist-domains.txt           #
 #                                                                                #
 #   Domains that should never be blocked can be put into a file named            #
 #   domains-allowlist.txt.                                                       #
 #                                                                                #
 #   That blocklist file can then be used in the dnscrypt-proxy.toml file:        #
 #                                                                                #
-#   [blocklist]                                                                  #
+#   [blocked_names]                                                              #
 #                                                                                #
-#   blocklist_file = 'dnscrypt-blocklist-domains.txt'                            #
+#     blocked_names_file = 'dnscrypt-blocklist-domains.txt'                      #
 #                                                                                #
 ##################################################################################
 


### PR DESCRIPTION
`blocklist` doesn't seem to be a valid key
https://github.com/DNSCrypt/dnscrypt-proxy/blob/1a82786e078d217caf40e06553a8f95398ffde4a/dnscrypt-proxy/config.go#L64-L65

so I changed it to the values from the main example config
https://github.com/DNSCrypt/dnscrypt-proxy/blob/09866acdb522b51ef1bc658a19c2ab84efafca67/dnscrypt-proxy/example-dnscrypt-proxy.toml#L506-L510