### PR TITLE
replace TrimFunc(s, IsSpace) with TrimSpace for ASCII optimization

### DIFF
--- a/dnscrypt-proxy/coldstart.go
+++ b/dnscrypt-proxy/coldstart.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/jedisct1/dlog"
 	"github.com/miekg/dns"
@@ -163,7 +162,7 @@ func ColdStart(proxy *Proxy) (*CaptivePortalHandler, error) {
 		}
 		var ips []net.IP
 		for _, ip := range strings.Split(ipsStr, ",") {
-			ipStr := strings.TrimFunc(ip, unicode.IsSpace)
+			ipStr := strings.TrimSpace(ip)
 			if ip := net.ParseIP(ipStr); ip != nil {
 				ips = append(ips, ip)
 			} else {

--- a/dnscrypt-proxy/common.go
+++ b/dnscrypt-proxy/common.go
@@ -126,7 +126,7 @@ func StringTwoFields(str string) (string, string, bool) {
 	if pos == -1 {
 		return "", "", false
 	}
-	a, b := strings.TrimFunc(str[:pos], unicode.IsSpace), strings.TrimFunc(str[pos+1:], unicode.IsSpace)
+	a, b := strings.TrimSpace(str[:pos]), strings.TrimSpace(str[pos+1:])
 	if len(a) == 0 || len(b) == 0 {
 		return a, b, false
 	}
@@ -156,7 +156,7 @@ func TrimAndStripInlineComments(str string) string {
 			str = str[:idx-1]
 		}
 	}
-	return strings.TrimFunc(str, unicode.IsSpace)
+	return strings.TrimSpace(str)
 }
 
 func ExtractHostAndPort(str string, defaultPort int) (host string, port int) {

--- a/dnscrypt-proxy/plugin_allow_name.go
+++ b/dnscrypt-proxy/plugin_allow_name.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/jedisct1/dlog"
 	"github.com/miekg/dns"
@@ -44,8 +43,8 @@ func (plugin *PluginAllowName) Init(proxy *Proxy) error {
 		parts := strings.Split(line, "@")
 		timeRangeName := ""
 		if len(parts) == 2 {
-			line = strings.TrimFunc(parts[0], unicode.IsSpace)
-			timeRangeName = strings.TrimFunc(parts[1], unicode.IsSpace)
+			line = strings.TrimSpace(parts[0])
+			timeRangeName = strings.TrimSpace(parts[1])
 		} else if len(parts) > 2 {
 			dlog.Errorf("Syntax error in allowed names at line %d -- Unexpected @ character", 1+lineNo)
 			continue

--- a/dnscrypt-proxy/plugin_block_name.go
+++ b/dnscrypt-proxy/plugin_block_name.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/jedisct1/dlog"
 	"github.com/miekg/dns"
@@ -101,8 +100,8 @@ func (plugin *PluginBlockName) Init(proxy *Proxy) error {
 		parts := strings.Split(line, "@")
 		timeRangeName := ""
 		if len(parts) == 2 {
-			line = strings.TrimFunc(parts[0], unicode.IsSpace)
-			timeRangeName = strings.TrimFunc(parts[1], unicode.IsSpace)
+			line = strings.TrimSpace(parts[0])
+			timeRangeName = strings.TrimSpace(parts[1])
 		} else if len(parts) > 2 {
 			dlog.Errorf("Syntax error in block rules at line %d -- Unexpected @ character", 1+lineNo)
 			continue

--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -52,8 +52,8 @@ func (plugin *PluginCloak) Init(proxy *Proxy) error {
 		var target string
 		parts := strings.FieldsFunc(line, unicode.IsSpace)
 		if len(parts) == 2 {
-			line = strings.TrimFunc(parts[0], unicode.IsSpace)
-			target = strings.TrimFunc(parts[1], unicode.IsSpace)
+			line = strings.TrimSpace(parts[0])
+			target = strings.TrimSpace(parts[1])
 		} else if len(parts) > 2 {
 			dlog.Errorf("Syntax error in cloaking rules at line %d -- Unexpected space character", 1+lineNo)
 			continue

--- a/dnscrypt-proxy/plugin_forward.go
+++ b/dnscrypt-proxy/plugin_forward.go
@@ -5,7 +5,6 @@ import (
 	"math/rand"
 	"net"
 	"strings"
-	"unicode"
 
 	"github.com/jedisct1/dlog"
 	"github.com/miekg/dns"
@@ -49,7 +48,7 @@ func (plugin *PluginForward) Init(proxy *Proxy) error {
 		domain = strings.ToLower(domain)
 		var servers []string
 		for _, server := range strings.Split(serversStr, ",") {
-			server = strings.TrimFunc(server, unicode.IsSpace)
+			server = strings.TrimSpace(server)
 			if net.ParseIP(server) != nil {
 				server = fmt.Sprintf("%s:%d", server, 53)
 			}

--- a/dnscrypt-proxy/sources.go
+++ b/dnscrypt-proxy/sources.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/dchest/safefile"
 
@@ -247,12 +246,12 @@ func (source *Source) parseV2() ([]RegisteredServer, error) {
 	}
 	parts = parts[1:]
 	for _, part := range parts {
-		part = strings.TrimFunc(part, unicode.IsSpace)
+		part = strings.TrimSpace(part)
 		subparts := strings.Split(part, "\n")
 		if len(subparts) < 2 {
 			return registeredServers, fmt.Errorf("Invalid format for source at [%v]", source.urls)
 		}
-		name := strings.TrimFunc(subparts[0], unicode.IsSpace)
+		name := strings.TrimSpace(subparts[0])
 		if len(name) == 0 {
 			return registeredServers, fmt.Errorf("Invalid format for source at [%v]", source.urls)
 		}
@@ -261,7 +260,7 @@ func (source *Source) parseV2() ([]RegisteredServer, error) {
 		var stampStr, description string
 		stampStrs := make([]string, 0)
 		for _, subpart := range subparts {
-			subpart = strings.TrimFunc(subpart, unicode.IsSpace)
+			subpart = strings.TrimSpace(subpart)
 			if strings.HasPrefix(subpart, "sdns:") && len(subpart) >= 6 {
 				stampStrs = append(stampStrs, subpart)
 				continue


### PR DESCRIPTION
Just a small cleanup that a linter turned up. `TrimSpace` is possibly a bit faster than `TrimFunc` with `IsSpace`, because if the string being trimmed only has ASCII spaces, it doesn't need to do the unicode check.