### PR TITLE
Temporarily disable `Geoffrey Frogeye's trackers list`

### DIFF
--- a/utils/generate-domains-blocklist/domains-blocklist.conf
+++ b/utils/generate-domains-blocklist/domains-blocklist.conf
@@ -75,7 +75,7 @@ https://raw.githubusercontent.com/nextdns/cname-cloaking-blocklist/master/domain
 # https://adguardteam.github.io/AdGuardSDNSFilter/Filters/filter.txt
 
 # Geoffrey Frogeye's block list of first-party trackers - https://hostfiles.frogeye.fr/
-https://hostfiles.frogeye.fr/firstparty-trackers.txt
+# https://hostfiles.frogeye.fr/firstparty-trackers.txt
 
 # CoinBlockerLists: blocks websites serving cryptocurrency miners - https://gitlab.com/ZeroDot1/CoinBlockerLists/ - Contains false positives
 # https://gitlab.com/ZeroDot1/CoinBlockerLists/raw/master/list_browser.txt


### PR DESCRIPTION
For `hostfiles.frogeye.fr` has been offline for hours.

Refer:
a. https://port.ping.pe/hostfiles.frogeye.fr:443
b. https://i.ping.pe/h/M/img_hMz19G0Y.png