### PR TITLE
Synchronously update the target configuration upon failure.

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -704,6 +704,7 @@ func (proxy *Proxy) processIncomingQuery(clientProto string, serverProto string,
 							if err = proxy.serversInfo.refreshServer(proxy, registeredServer.name, registeredServer.stamp); err != nil {
 								// Failed to refresh the proxy server information.
 								dlog.Notice("Key update failed")
+								serverInfo.noticeFailure(proxy)
 							}
 							break
 						}

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -698,12 +698,12 @@ func (proxy *Proxy) processIncomingQuery(clientProto string, serverProto string,
 						response = nil
 					}
 				} else if responseCode == 401 {
-					dlog.Notice("Forcing key update")
+					dlog.Notice("Forcing key update for " + serverInfo.Name)
 					for _, registeredServer := range proxy.serversInfo.registeredServers {
 						if registeredServer.name == serverInfo.Name {
 							if err = proxy.serversInfo.refreshServer(proxy, registeredServer.name, registeredServer.stamp); err != nil {
 								// Failed to refresh the proxy server information.
-								dlog.Notice("Key update failed")
+								dlog.Notice("Key update failed for " + serverInfo.Name)
 								serverInfo.noticeFailure(proxy)
 							}
 							break

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -699,7 +699,15 @@ func (proxy *Proxy) processIncomingQuery(clientProto string, serverProto string,
 					}
 				} else if responseCode == 401 {
 					dlog.Notice("Forcing key update")
-					go proxy.serversInfo.refresh(proxy)
+					for _, registeredServer := range proxy.serversInfo.registeredServers {
+						if registeredServer.name == serverInfo.Name {
+							if err = proxy.serversInfo.refreshServer(proxy, registeredServer.name, registeredServer.stamp); err != nil {
+								// Failed to refresh the proxy server information.
+								dlog.Notice("Key update failed")
+							}
+							break
+						}
+					}
 					response = nil
 				} else {
 					dlog.Error("Failed to receive successful response")


### PR DESCRIPTION
If the target _fails_ to update, nothing else is done. This relies on the load balancer to try and resolve the query via some other server. This is an exceptional case, so we could definitely do something different here, e.g., remove the target from the list of registered servers. 

@jedisct1, do you think something different should be done here? I'm totally open to alternate recovery flows!