### PR TITLE
Add missing return at end of function

### DIFF
--- a/dnscrypt-proxy/odoh.go
+++ b/dnscrypt-proxy/odoh.go
@@ -84,7 +84,7 @@ func parseODoHTargetConfigs(configs []byte) ([]ODoHTargetConfig, error) {
 		}
 		offset = offset + int(configLength) + 4
 		if len(targets) >= maxODoHConfigs {
-			break
+			return nil, fmt.Errorf("Maximum configs reached")
 		}
 	}
 }


### PR DESCRIPTION
./odoh.go:90:1: missing return at end of function

fixes: "Limit the number of ODoH target configs"