### PR TITLE
Let Dependabot update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,13 @@
 version: 2
 
 updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      
+  # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION

This will make it so that Dependabot is able to submit pull requests to keep GitHub Actions up to date.