### PR TITLE
fix minor typo in example config

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -214,7 +214,7 @@ cert_refresh_delay = 240
 ## Bootstrap resolvers
 ##
 ## These are normal, non-encrypted DNS resolvers, that will be only used
-## for one-shot queries when retrieving the initial resolvers list and the
+## for one-shot queries when retrieving the initial resolvers list and if
 ## the system DNS configuration doesn't work.
 ##
 ## No user queries will ever be leaked through these resolvers, and they will


### PR DESCRIPTION
I just upgraded to 2.1.0 (great job, everyone!) and noticed a small typo when merging in the new example config to my existing one.