### PR TITLE
allow ptr queries for cloaked domains

### DIFF
--- a/.ci/ci-test.sh
+++ b/.ci/ci-test.sh
@@ -70,6 +70,7 @@ t || dig -p${DNS_PORT} +short cloaked.com @127.0.0.1 | grep -Eq '1.1.1.1|1.0.0.1
 t || dig -p${DNS_PORT} +short www.cloaked2.com @127.0.0.1 | grep -Eq '1.1.1.1|1.0.0.1' || fail
 t || dig -p${DNS_PORT} +short www.dnscrypt-test @127.0.0.1 | grep -Fq '192.168.100.100' || fail
 t || dig -p${DNS_PORT} a.www.dnscrypt-test @127.0.0.1 | grep -Fq 'NXDOMAIN' || fail
+t || dig -p${DNS_PORT} +short ptr 101.100.168.192.in-addr.arpa. @127.0.0.1 | grep -Eq 'www.dnscrypt-test.com' || fail
 
 section
 t || dig -p${DNS_PORT} telemetry.example @127.0.0.1 | grep -Fq 'locally blocked' || fail

--- a/.ci/ci-test.sh
+++ b/.ci/ci-test.sh
@@ -71,6 +71,7 @@ t || dig -p${DNS_PORT} +short www.cloaked2.com @127.0.0.1 | grep -Eq '1.1.1.1|1.
 t || dig -p${DNS_PORT} +short www.dnscrypt-test @127.0.0.1 | grep -Fq '192.168.100.100' || fail
 t || dig -p${DNS_PORT} a.www.dnscrypt-test @127.0.0.1 | grep -Fq 'NXDOMAIN' || fail
 t || dig -p${DNS_PORT} +short ptr 101.100.168.192.in-addr.arpa. @127.0.0.1 | grep -Eq 'www.dnscrypt-test.com' || fail
+t || dig -p${DNS_PORT} +short ptr 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.d.f.ip6.arpa. @127.0.0.1 | grep -Eq 'ipv6.dnscrypt-test.com' || fail
 
 section
 t || dig -p${DNS_PORT} telemetry.example @127.0.0.1 | grep -Fq 'locally blocked' || fail

--- a/.ci/cloaking-rules.txt
+++ b/.ci/cloaking-rules.txt
@@ -1,3 +1,4 @@
 cloaked.*                one.one.one.one
 *.cloaked2.*             one.one.one.one # inline comment
 =www.dnscrypt-test       192.168.100.100
+=www.dnscrypt-test.com   192.168.100.101

--- a/.ci/cloaking-rules.txt
+++ b/.ci/cloaking-rules.txt
@@ -2,3 +2,4 @@ cloaked.*                one.one.one.one
 *.cloaked2.*             one.one.one.one # inline comment
 =www.dnscrypt-test       192.168.100.100
 =www.dnscrypt-test.com   192.168.100.101
+=ipv6.dnscrypt-test.com   fd02::1

--- a/.ci/test2-dnscrypt-proxy.toml
+++ b/.ci/test2-dnscrypt-proxy.toml
@@ -10,6 +10,7 @@ block_unqualified = true
 block_undelegated = true
 forwarding_rules = 'forwarding-rules.txt'
 cloaking_rules = 'cloaking-rules.txt'
+cloak_ptr = true
 cache = true
 
 [local_doh]

--- a/dnscrypt-proxy/common.go
+++ b/dnscrypt-proxy/common.go
@@ -47,6 +47,11 @@ const (
 	InheritedDescriptorsBase = uintptr(50)
 )
 
+const (
+	IPv4Arpa = "in-addr.arpa"
+	IPv6Arpa = "ip6.arpa"
+)
+
 func PrefixWithSize(packet []byte) ([]byte, error) {
 	packetLen := len(packet)
 	if packetLen > 0xffff {
@@ -176,4 +181,37 @@ func ReadTextFile(filename string) (string, error) {
 	}
 	bin = bytes.TrimPrefix(bin, []byte{0xef, 0xbb, 0xbf})
 	return string(bin), nil
+}
+
+// Reverse an IPV4 Address
+// Borrwed from https://github.com/coredns/coredns/blob/master/plugin/pkg/dnsutil/reverse.go
+func reverseIPv4(slice []string) string {
+	for i := 0; i < len(slice)/2; i++ {
+		j := len(slice) - i - 1
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+	ip := net.ParseIP(strings.Join(slice, ".")).To4()
+	if ip == nil {
+		return ""
+	}
+	s := []string{ip.String(), IPv4Arpa}
+	return strings.Join(s, ".")
+}
+
+// Reverse an IPV6 Address
+func reverseIPv6(slice []string) string {
+	for i := 0; i < len(slice)/2; i++ {
+		j := len(slice) - i - 1
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+	slice6 := []string{}
+	for i := 0; i < len(slice)/4; i++ {
+		slice6 = append(slice6, strings.Join(slice[i*4:i*4+4], ""))
+	}
+	ip := net.ParseIP(strings.Join(slice6, ":")).To16()
+	if ip == nil {
+		return ""
+	}
+	s := []string{ip.String(), IPv6Arpa}
+	return strings.Join(s, ".")
 }

--- a/dnscrypt-proxy/common.go
+++ b/dnscrypt-proxy/common.go
@@ -182,36 +182,3 @@ func ReadTextFile(filename string) (string, error) {
 	bin = bytes.TrimPrefix(bin, []byte{0xef, 0xbb, 0xbf})
 	return string(bin), nil
 }
-
-// Reverse an IPV4 Address
-// Borrwed from https://github.com/coredns/coredns/blob/master/plugin/pkg/dnsutil/reverse.go
-func reverseIPv4(slice []string) string {
-	for i := 0; i < len(slice)/2; i++ {
-		j := len(slice) - i - 1
-		slice[i], slice[j] = slice[j], slice[i]
-	}
-	ip := net.ParseIP(strings.Join(slice, ".")).To4()
-	if ip == nil {
-		return ""
-	}
-	s := []string{ip.String(), IPv4Arpa}
-	return strings.Join(s, ".")
-}
-
-// Reverse an IPV6 Address
-func reverseIPv6(slice []string) string {
-	for i := 0; i < len(slice)/2; i++ {
-		j := len(slice) - i - 1
-		slice[i], slice[j] = slice[j], slice[i]
-	}
-	slice6 := []string{}
-	for i := 0; i < len(slice)/4; i++ {
-		slice6 = append(slice6, strings.Join(slice[i*4:i*4+4], ""))
-	}
-	ip := net.ParseIP(strings.Join(slice6, ":")).To16()
-	if ip == nil {
-		return ""
-	}
-	s := []string{ip.String(), IPv6Arpa}
-	return strings.Join(s, ".")
-}

--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -98,6 +98,7 @@ type Config struct {
 	RefusedCodeInResponses   bool                        `toml:"refused_code_in_responses"`
 	BlockedQueryResponse     string                      `toml:"blocked_query_response"`
 	QueryMeta                []string                    `toml:"query_meta"`
+	CloakedPTR				 bool						 `toml:"cloak_ptr"`
 	AnonymizedDNS            AnonymizedDNSConfig         `toml:"anonymized_dns"`
 	DoHClientX509Auth        DoHClientX509AuthConfig     `toml:"doh_client_x509_auth"`
 	DoHClientX509AuthLegacy  DoHClientX509AuthConfig     `toml:"tls_client_auth"`
@@ -154,6 +155,7 @@ func newConfig() Config {
 		AnonymizedDNS: AnonymizedDNSConfig{
 			DirectCertFallback: true,
 		},
+		CloakedPTR:               false,
 	}
 }
 
@@ -484,6 +486,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.cacheMaxTTL = config.CacheMaxTTL
 	proxy.rejectTTL = config.RejectTTL
 	proxy.cloakTTL = config.CloakTTL
+	proxy.cloakedPTR = config.CloakedPTR
 
 	proxy.queryMeta = config.QueryMeta
 

--- a/dnscrypt-proxy/example-cloaking-rules.txt
+++ b/dnscrypt-proxy/example-cloaking-rules.txt
@@ -35,3 +35,10 @@ localhost                ::1
 # ads.*                 192.168.100.1
 # ads.*                 192.168.100.2
 # ads.*                 ::1
+
+# PTR records can be created by setting cloak_ptr in the main configuration file
+# Entries with wild cards will not have PTR records created, but multiple 
+# names for the same IP are supported 
+
+# example.com           192.168.100.1
+# my.example.com        192.168.100.1

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -352,6 +352,8 @@ reject_ttl = 10
 ## Cloaking returns a predefined address for a specific name.
 ## In addition to acting as a HOSTS file, it can also return the IP address
 ## of a different name. It will also do CNAME flattening.
+## If 'cloak_ptr' is set, then PTR (reverse lookups) are enabled
+## for cloaking rules that do not contain wild cards.
 ##
 ## See the `example-cloaking-rules.txt` file for an example
 
@@ -360,6 +362,7 @@ reject_ttl = 10
 ## TTL used when serving entries in cloaking-rules.txt
 
 # cloak_ttl = 600
+# cloak_ptr = false
 
 
 

--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -26,6 +26,7 @@ type PluginCloak struct {
 	sync.RWMutex
 	patternMatcher *PatternMatcher
 	ttl            uint32
+	createPTR      bool
 }
 
 func (plugin *PluginCloak) Name() string {
@@ -43,6 +44,7 @@ func (plugin *PluginCloak) Init(proxy *Proxy) error {
 		return err
 	}
 	plugin.ttl = proxy.cloakTTL
+	plugin.createPTR = proxy.cloakedPTR
 	plugin.patternMatcher = NewPatternMatcher()
 	cloakedNames := make(map[string]*CloakedName)
 	for lineNo, line := range strings.Split(string(bin), "\n") {
@@ -85,7 +87,7 @@ func (plugin *PluginCloak) Init(proxy *Proxy) error {
 		cloakedName.lineNo = lineNo + 1
 		cloakedNames[line] = cloakedName
 
-		if strings.Contains(line, "*") || !cloakedName.isIP == true {
+		if !plugin.createPTR || strings.Contains(line, "*") || !cloakedName.isIP == true {
 			continue
 		}
 

--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -93,10 +93,11 @@ func (plugin *PluginCloak) Init(proxy *Proxy) error {
 
 		var ptrLine string
 		if ipv4 := ip.To4(); ipv4 != nil {
-			ptrLine = reverseIPv4(strings.Split(ip.String(), "."))
-
+			reversed, _ :=  dns.ReverseAddr(ip.To4().String())
+			ptrLine = strings.TrimSuffix(reversed, ".")
 		} else {
-			ptrLine = reverseIPv6(strings.Split(string(cloakedName.ipv6[0]), ":"))
+			reversed, _ := dns.ReverseAddr(cloakedName.ipv6[0].To16().String())
+			ptrLine = strings.TrimSuffix(reversed, ".")
 		}
 		ptrQueryLine := ptrEntryToQuery(ptrLine)
 		ptrCloakedName, found := cloakedNames[ptrQueryLine]
@@ -121,6 +122,7 @@ func ptrEntryToQuery(ptrEntry string) string {
 }
 
 func ptrNameToFQDN(ptrLine string) string {
+	ptrLine = strings.TrimPrefix(ptrLine, "=")
 	return ptrLine + "."
 }
 

--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -96,16 +96,15 @@ func (plugin *PluginCloak) Init(proxy *Proxy) error {
 		} else {
 			ptrLine = reverseIPv6(strings.Split(string(cloakedName.ipv6[0]), ":"))
 		}
-		ptrCloakedName, found := cloakedNames["="+ptrLine]
+		ptrQueryLine := ptrEntryToQuery(ptrLine)
+		ptrCloakedName, found := cloakedNames[ptrQueryLine]
 		if !found {
 			ptrCloakedName = &CloakedName{}
 		}
 		ptrCloakedName.isIP = true
-		// note that the fully qualified name must end with a .
-		ptrCloakedName.PTR = append((*ptrCloakedName).PTR, line+".")
+		ptrCloakedName.PTR = append((*ptrCloakedName).PTR, ptrNameToFQDN(line))
 		ptrCloakedName.lineNo = lineNo + 1
-		cloakedNames["="+ptrLine] = ptrCloakedName
-
+		cloakedNames[ptrQueryLine] = ptrCloakedName
 	}
 	for line, cloakedName := range cloakedNames {
 		if err := plugin.patternMatcher.Add(line, cloakedName, cloakedName.lineNo); err != nil {
@@ -113,6 +112,14 @@ func (plugin *PluginCloak) Init(proxy *Proxy) error {
 		}
 	}
 	return nil
+}
+
+func ptrEntryToQuery(ptrEntry string) string {
+	return "=" + ptrEntry
+}
+
+func ptrNameToFQDN(ptrLine string) string {
+	return ptrLine + "."
 }
 
 func (plugin *PluginCloak) Drop() error {

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -83,6 +83,7 @@ type Proxy struct {
 	cacheMinTTL                   uint32
 	cacheNegMaxTTL                uint32
 	cloakTTL                      uint32
+	cloakedPTR					  bool
 	cache                         bool
 	pluginBlockIPv6               bool
 	ephemeralKeys                 bool


### PR DESCRIPTION
**STATUS: Ready for Review**

@jedisct1  
PR for https://github.com/DNSCrypt/dnscrypt-proxy/discussions/1939  to support PTR records for cloaked domains.
Functions for multiple entries per IP address; 
Comments / observations welcome.

**Outline**
Create PTR records for cloaked domains.  Scope only for entries with no wildcards

**Changes**
Create PTR record for all non-wild carded cloaked entries when parsing file
Cloak Plugin responds to PTR requests
New config element 'cloak_ptr'  to enable this feature ( default is false )
