### PR TITLE
systemd: use constants and update status on ready

### DIFF
--- a/dnscrypt-proxy/service_linux.go
+++ b/dnscrypt-proxy/service_linux.go
@@ -8,13 +8,15 @@ import (
 	clocksmith "github.com/jedisct1/go-clocksmith"
 )
 
+const SdNotifyStatus = "STATUS="
+
 func ServiceManagerStartNotify() error {
-	daemon.SdNotify(false, "STATUS=Starting")
+	daemon.SdNotify(false, SdNotifyStatus+"Starting...")
 	return nil
 }
 
 func ServiceManagerReadyNotify() error {
-	daemon.SdNotify(false, "READY=1")
+	daemon.SdNotify(false, daemon.SdNotifyReady+"\n"+SdNotifyStatus+"Ready")
 	return systemDWatchdog()
 }
 
@@ -26,10 +28,9 @@ func systemDWatchdog() error {
 	refreshInterval := watchdogFailureDelay / 3
 	go func() {
 		for {
-			daemon.SdNotify(false, "WATCHDOG=1")
+			daemon.SdNotify(false, daemon.SdNotifyWatchdog)
 			clocksmith.Sleep(refreshInterval)
 		}
-
 	}()
 	return nil
 }


### PR DESCRIPTION
Systemd-notify signaling indicates the status of dnscrypt-proxy when
starting as 'Type=notify' systemd service. However, the status is not
updated when initialization completes, instead it always shows
"Starting". Now fixed.