### PR TITLE
Change bootstrap resolver Quad9 (with ECS)

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -241,7 +241,7 @@ cert_refresh_delay = 240
 ## not be sent there. If you're using DNSCrypt or Anonymized DNS and your
 ## lists are up to date, these resolvers will not even be used.
 
-bootstrap_resolvers = ['9.9.9.9:53', '8.8.8.8:53']
+bootstrap_resolvers = ['9.9.9.11:53', '8.8.8.8:53']
 
 
 ## Always use the bootstrap resolver before the system DNS settings.


### PR DESCRIPTION
Server Quad9 info https://www.quad9.net/service/service-addresses-and-features

The nextdns ultralow server was recently added, but domains resolved via the Quad9 server (without ECS) may cause `nextdns-ultralow` to work incorrectly for users in that country. So I suggest to switch to using Quad9 (with ECS) which is similar to Google DNS bootstrap resolver.

From https://github.com/DNSCrypt/dnscrypt-resolvers/issues/638

I live in Vietnam, but if using 9.9.9.9, the returning servers will be in Singapore

```
; <<>> DiG 9.11.3-1ubuntu1.16-Ubuntu <<>> dns.nextdns.io @9.9.9.9
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 4888
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;dns.nextdns.io.			IN	A

;; ANSWER SECTION:
dns.nextdns.io.		289	IN	CNAME	steering.nextdns.io.
steering.nextdns.io.	49	IN	A	103.62.48.147
steering.nextdns.io.	49	IN	A	217.146.9.93

;; Query time: 62 msec
;; SERVER: 9.9.9.9#53(9.9.9.9)
;; WHEN: Wed Feb 16 10:04:37 +07 2022
;; MSG SIZE  rcvd: 98
```

But if using 9.9.9.11, the servers are all in Vietnam

```
; <<>> DiG 9.11.3-1ubuntu1.16-Ubuntu <<>> dns.nextdns.io @9.9.9.11
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 11996
;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 8003ee986a373c0a90e09d04620c6a125d10079ace398b8d (good)
;; QUESTION SECTION:
;dns.nextdns.io.			IN	A

;; ANSWER SECTION:
dns.nextdns.io.		300	IN	CNAME	steering.nextdns.io.
steering.nextdns.io.	60	IN	A	203.162.172.59
steering.nextdns.io.	60	IN	A	103.199.17.192

;; Query time: 305 msec
;; SERVER: 9.9.9.11#53(9.9.9.11)
;; WHEN: Wed Feb 16 10:05:54 +07 2022
```

Hope you will consider to change this. Thank you!