### PR TITLE
Reload expired client certificates

### DIFF
--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -442,6 +442,11 @@ func (xTransport *XTransport) Fetch(
 			)
 			xTransport.tlsCipherSuite = nil
 			xTransport.rebuildTransport()
+		} else if len(xTransport.tlsClientCreds.clientCert) > 0 && strings.Contains(err.Error(), "bad certificate") {
+			dlog.Warnf(
+				"TLS certificate failure - Check the validity of the client certificate; reloading existing certificate",
+			)
+			xTransport.rebuildTransport()
 		}
 		return nil, statusCode, nil, rtt, err
 	}


### PR DESCRIPTION
When the client credentials used for mutual authentication expire, all requests
to a DoH server which enforces validitiy will fail. To mitigate this, we can
try to reload the existing credentials from disk. This assumes that the
credentials have been rotated outside of the dnscrypt-proxy process and thus a
reload will pick up the newest versions.

The simplest way to do this is to simply rebuild the transport upon receiving
an error which contains the string "bad certificate".

Resolves #2114