### PR TITLE
PluginDNS64: Use read and write mutexes as approp

### DIFF
--- a/dnscrypt-proxy/plugin_dns64.go
+++ b/dnscrypt-proxy/plugin_dns64.go
@@ -39,8 +39,8 @@ func (plugin *PluginDNS64) Init(proxy *Proxy) error {
 	plugin.proxy = proxy
 
 	if len(proxy.dns64Prefixes) != 0 {
-		plugin.pref64Mutex.RLock()
-		defer plugin.pref64Mutex.RUnlock()
+		plugin.pref64Mutex.Lock()
+		defer plugin.pref64Mutex.Unlock()
 		for _, prefStr := range proxy.dns64Prefixes {
 			_, pref, err := net.ParseCIDR(prefStr)
 			if err != nil {
@@ -129,7 +129,7 @@ func (plugin *PluginDNS64) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 
 			ipv4 := answer.(*dns.A).A.To4()
 			if ipv4 != nil {
-				plugin.pref64Mutex.Lock()
+				plugin.pref64Mutex.RLock()
 				for _, prefix := range plugin.pref64 {
 					ipv6 := translateToIPv6(ipv4, prefix)
 					synthAAAA := new(dns.AAAA)
@@ -142,7 +142,7 @@ func (plugin *PluginDNS64) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 					synthAAAA.AAAA = ipv6
 					synthAAAAs = append(synthAAAAs, synthAAAA)
 				}
-				plugin.pref64Mutex.Unlock()
+				plugin.pref64Mutex.RUnlock()
 			}
 		}
 	}
@@ -236,8 +236,8 @@ func (plugin *PluginDNS64) fetchPref64(resolver string) error {
 		return errors.New("Empty Pref64 list")
 	}
 
-	plugin.pref64Mutex.RLock()
-	defer plugin.pref64Mutex.RUnlock()
+	plugin.pref64Mutex.Lock()
+	defer plugin.pref64Mutex.Unlock()
 	plugin.pref64 = prefixes
 	return nil
 }
@@ -249,8 +249,8 @@ func (plugin *PluginDNS64) refreshPref64() error {
 		}
 	}
 
-	plugin.pref64Mutex.Lock()
-	defer plugin.pref64Mutex.Unlock()
+	plugin.pref64Mutex.RLock()
+	defer plugin.pref64Mutex.RUnlock()
 	if len(plugin.pref64) == 0 {
 		return errors.New("Empty Pref64 list")
 	}


### PR DESCRIPTION
If the lock is intended to protect `plugin.pref64`, then the current change may make sense. Otherwise, I might have gotten this commit upside down.