### PR TITLE
Use registeredServers slice copy during ServerInfo refreshing period

### DIFF
--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -223,7 +223,9 @@ func (serversInfo *ServersInfo) refreshServer(proxy *Proxy, name string, stamp s
 func (serversInfo *ServersInfo) refresh(proxy *Proxy) (int, error) {
 	dlog.Debug("Refreshing certificates")
 	serversInfo.RLock()
-	registeredServers := serversInfo.registeredServers
+	// Appending registeredServers slice from sources may allocate new memory.
+	registeredServers := make([]RegisteredServer, len(serversInfo.registeredServers))
+	copy(registeredServers, serversInfo.registeredServers)
 	serversInfo.RUnlock()
 	liveServers := 0
 	var err error


### PR DESCRIPTION
goroutines:
[proxy.updateRegisteredServers()](https://github.com/DNSCrypt/dnscrypt-proxy/blob/8d737a69f550158ed6a08aef46bdb975ac6e47cb/dnscrypt-proxy/proxy.go#L257) versus [proxy.serversInfo.refresh(proxy)](https://github.com/DNSCrypt/dnscrypt-proxy/blob/8d737a69f550158ed6a08aef46bdb975ac6e47cb/dnscrypt-proxy/proxy.go#L269)