### PR TITLE
Fix goroutines memory leak by unbuffered channel blocking

### DIFF
--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -316,7 +316,7 @@ func DNSExchange(
 ) (*dns.Msg, time.Duration, bool, error) {
 	for {
 		cancelChannel := make(chan struct{})
-		channel := make(chan DNSExchangeResponse)
+		channel := make(chan DNSExchangeResponse, 6)
 		var err error
 		options := 0
 
@@ -325,32 +325,32 @@ func DNSExchange(
 				queryCopy := query.Copy()
 				queryCopy.Id += uint16(options)
 				go func(query *dns.Msg, delay time.Duration) {
-					option := _dnsExchange(proxy, proto, query, serverAddress, relay, 1500)
+					time.Sleep(delay)
+					option := DNSExchangeResponse{err: errors.New("Canceled")}
+					select {
+					case <-cancelChannel:
+					default:
+						option = _dnsExchange(proxy, proto, query, serverAddress, relay, 1500)
+					}
 					option.fragmentsBlocked = false
 					option.priority = 0
 					channel <- option
-					time.Sleep(delay)
-					select {
-					case <-cancelChannel:
-						return
-					default:
-					}
 				}(queryCopy, time.Duration(200*tries)*time.Millisecond)
 				options++
 			}
 			queryCopy := query.Copy()
 			queryCopy.Id += uint16(options)
 			go func(query *dns.Msg, delay time.Duration) {
-				option := _dnsExchange(proxy, proto, query, serverAddress, relay, 480)
+				time.Sleep(delay)
+				option := DNSExchangeResponse{err: errors.New("Canceled")}
+				select {
+				case <-cancelChannel:
+				default:
+					option = _dnsExchange(proxy, proto, query, serverAddress, relay, 480)
+				}
 				option.fragmentsBlocked = true
 				option.priority = 1
 				channel <- option
-				time.Sleep(delay)
-				select {
-				case <-cancelChannel:
-					return
-				default:
-				}
 			}(queryCopy, time.Duration(250*tries)*time.Millisecond)
 			options++
 		}


### PR DESCRIPTION
Seems there is a mysterious issue of memory climbing up, uncaught, I suspected.
That is because of, in my mind, `dnscrypt-proxy` will cost 30+M private memory after several days, while it costs ~13M at launch.

Recently, I did some profiling and get the following details.

1. A `typeperf` (on Windows) samples analysis. They are sampled per 5 minutes, and 573 samples.
    ![2865m](https://user-images.githubusercontent.com/19585474/176193681-07e1402a-561c-43e1-a887-41d6ea523ecf.png)

    `dnscrypt-proxy`: upstream DNS of `dnsforwarder`, no caching, no any lists.
    `dnsforwarder`: default DNS, caching, types of lists.
    `pd`: http proxy, important traffic indicator, also a go program.

    Here we can see the climbing up. That will be strange, considering I use it as a bare proxy. The comparison of the 3 tells it is unlikely the system memory management issue.

2. I did `go tool pprof` on `dnscrypt-proxy`, and found it is the goroutines, rather than the heap.
    There were about 160 goroutines while it is idle, after working 7h. Too much! Built on https://github.com/DNSCrypt/dnscrypt-proxy/commit/59ce17e0abe8297182f19ed2e841051193f62ad3.
    ```
    goroutine profile: total 163
    82 @ 0xc3a48f 0xc04a40 0xc04734 0xf86815 0xc666b1
    #	0xf86814	main.DNSExchange.func1+0xa4	github.com/dnscrypt/dnscrypt-proxy/dnscrypt-proxy/dnsutils.go:331

    71 @ 0xc3a48f 0xc04a40 0xc04734 0xf866d5 0xc666b1
    #	0xf866d4	main.DNSExchange.func2+0xa4	github.com/dnscrypt/dnscrypt-proxy/dnscrypt-proxy/dnsutils.go:347
    ```
    The channel blocks, and the goroutine hangs on!

Blocking PoC for **unbuffered channels** Vs **buffered channels**: https://gist.github.com/lifenjoiner/16d279ddfc0e6b81b1d4082c6cff3c1f

With this patch, the goroutines total will be about 14 while it is idle, after working 7h.

Here is a comparison for the first 8h:
Before:
![0627](https://user-images.githubusercontent.com/19585474/176193955-38829adc-f5d2-419b-8356-dfded0ec4288.gif)

After:
![0628](https://user-images.githubusercontent.com/19585474/176194003-7e7b7104-2a4f-4590-926e-b575d4c7647f.gif)
The positive correlation with `pd` can be seen.

I'm still profiling the memory usage for longer term performance ... Hope there will be good news.
