### PR TITLE
xtransport layer to netip and immediate dependencies

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -926,7 +926,7 @@ func cdLocal() {
 
 func isIPAndPort(addrStr string) error {
 	host, port := ExtractHostAndPort(addrStr, -1)
-	if ip := ParseIP(host); ip == nil {
+	if _, err := ParseIP(host); err != nil {
 		return fmt.Errorf("Host does not parse as IP '%s'", addrStr)
 	} else if port == -1 {
 		return fmt.Errorf("Port missing '%s'", addrStr)

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -260,7 +260,7 @@ func (serversInfo *ServersInfo) estimatorUpdate(currentActive int) {
 	if activeCount == serversCount {
 		return
 	}
-	candidate := rand.Intn(serversCount-activeCount)+activeCount
+	candidate := rand.Intn(serversCount-activeCount) + activeCount
 	candidateRtt, currentActiveRtt := serversInfo.inner[candidate].rtt.Value(), serversInfo.inner[currentActive].rtt.Value()
 	if currentActiveRtt < 0 {
 		currentActiveRtt = candidateRtt
@@ -529,7 +529,7 @@ func route(proxy *Proxy, name string, serverProto stamps.StampProtoType) (*Relay
 		}
 		if len(relayCandidateStamp.ServerAddrStr) > 0 {
 			ipOnly, _ := ExtractHostAndPort(relayCandidateStamp.ServerAddrStr, -1)
-			if ip := ParseIP(ipOnly); ip != nil {
+			if ip, err := ParseIP(ipOnly); err != nil {
 				host, _ := ExtractHostAndPort(relayCandidateStamp.ProviderName, -1)
 				proxy.xTransport.saveCachedIP(host, ip, -1*time.Second)
 			}
@@ -665,7 +665,7 @@ func fetchDoHServerInfo(proxy *Proxy, name string, stamp stamps.ServerStamp, isN
 	// in order to fingerprint clients across multiple IP addresses.
 	if len(stamp.ServerAddrStr) > 0 {
 		ipOnly, _ := ExtractHostAndPort(stamp.ServerAddrStr, -1)
-		if ip := ParseIP(ipOnly); ip != nil {
+		if ip, err := ParseIP(ipOnly); err != nil {
 			host, _ := ExtractHostAndPort(stamp.ProviderName, -1)
 			proxy.xTransport.saveCachedIP(host, ip, -1*time.Second)
 		}

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
@@ -38,7 +39,7 @@ const (
 )
 
 type CachedIPItem struct {
-	ip         net.IP
+	ip         netip.Addr
 	expiration *time.Time
 }
 
@@ -91,13 +92,13 @@ func NewXTransport() *XTransport {
 	return &xTransport
 }
 
-func ParseIP(ipStr string) net.IP {
-	return net.ParseIP(strings.TrimRight(strings.TrimLeft(ipStr, "["), "]"))
+func ParseIP(ipStr string) (netip.Addr, error) {
+	return netip.ParseAddr(strings.TrimRight(strings.TrimLeft(ipStr, "["), "]"))
 }
 
 // If ttl < 0, never expire
 // Otherwise, ttl is set to max(ttl, MinResolverIPTTL)
-func (xTransport *XTransport) saveCachedIP(host string, ip net.IP, ttl time.Duration) {
+func (xTransport *XTransport) saveCachedIP(host string, ip netip.Addr, ttl time.Duration) {
 	item := &CachedIPItem{ip: ip, expiration: nil}
 	if ttl >= 0 {
 		if ttl < MinResolverIPTTL {
@@ -111,8 +112,8 @@ func (xTransport *XTransport) saveCachedIP(host string, ip net.IP, ttl time.Dura
 	xTransport.cachedIPs.Unlock()
 }
 
-func (xTransport *XTransport) loadCachedIP(host string) (ip net.IP, expired bool) {
-	ip, expired = nil, false
+func (xTransport *XTransport) loadCachedIP(host string) (ip netip.Addr, expired bool) {
+	ip, expired = netip.IPv4Unspecified(), false
 	xTransport.cachedIPs.RLock()
 	item, ok := xTransport.cachedIPs.cache[host]
 	xTransport.cachedIPs.RUnlock()
@@ -147,9 +148,9 @@ func (xTransport *XTransport) rebuildTransport() {
 			// resolveAndUpdateCache() is always called in `Fetch()` before the `Dial()`
 			// method is used, so that a cached entry must be present at this point.
 			cachedIP, _ := xTransport.loadCachedIP(host)
-			if cachedIP != nil {
-				if ipv4 := cachedIP.To4(); ipv4 != nil {
-					ipOnly = ipv4.String()
+			if cachedIP != netip.IPv4Unspecified() {
+				if cachedIP.Is4() {
+					ipOnly = cachedIP.String()
 				} else {
 					ipOnly = "[" + cachedIP.String() + "]"
 				}
@@ -225,23 +226,23 @@ func (xTransport *XTransport) rebuildTransport() {
 	xTransport.h3Transport = h3Transport
 }
 
-func (xTransport *XTransport) resolveUsingSystem(host string) (ip net.IP, ttl time.Duration, err error) {
+func (xTransport *XTransport) resolveUsingSystem(host string) (ip netip.Addr, ttl time.Duration, err error) {
 	ttl = SystemResolverIPTTL
 	var foundIPs []string
 	foundIPs, err = net.LookupHost(host)
 	if err != nil {
 		return
 	}
-	ips := make([]net.IP, 0)
+	ips := make([]netip.Addr, 0)
 	for _, ip := range foundIPs {
-		if foundIP := net.ParseIP(ip); foundIP != nil {
+		if foundIP, err := netip.ParseAddr(ip); err == nil {
 			if xTransport.useIPv4 {
-				if ipv4 := foundIP.To4(); ipv4 != nil {
+				if foundIP.Is4() {
 					ips = append(ips, foundIP)
 				}
 			}
 			if xTransport.useIPv6 {
-				if ipv6 := foundIP.To16(); ipv6 != nil {
+				if foundIP.Is6() || foundIP.Is4In6() {
 					ips = append(ips, foundIP)
 				}
 			}
@@ -256,7 +257,7 @@ func (xTransport *XTransport) resolveUsingSystem(host string) (ip net.IP, ttl ti
 func (xTransport *XTransport) resolveUsingResolver(
 	proto, host string,
 	resolver string,
-) (ip net.IP, ttl time.Duration, err error) {
+) (ip netip.Addr, ttl time.Duration, err error) {
 	dnsClient := dns.Client{Net: proto}
 	if xTransport.useIPv4 {
 		msg := dns.Msg{}
@@ -272,7 +273,7 @@ func (xTransport *XTransport) resolveUsingResolver(
 			}
 			if len(answers) > 0 {
 				answer := answers[rand.Intn(len(answers))]
-				ip = answer.(*dns.A).A
+				ip, _ = netip.ParseAddr(answer.(*dns.A).A.String())
 				ttl = time.Duration(answer.Header().Ttl) * time.Second
 				return
 			}
@@ -292,7 +293,7 @@ func (xTransport *XTransport) resolveUsingResolver(
 			}
 			if len(answers) > 0 {
 				answer := answers[rand.Intn(len(answers))]
-				ip = answer.(*dns.AAAA).AAAA
+				ip, _ = netip.ParseAddr(answer.(*dns.AAAA).AAAA.String())
 				ttl = time.Duration(answer.Header().Ttl) * time.Second
 				return
 			}
@@ -304,7 +305,7 @@ func (xTransport *XTransport) resolveUsingResolver(
 func (xTransport *XTransport) resolveUsingResolvers(
 	proto, host string,
 	resolvers []string,
-) (ip net.IP, ttl time.Duration, err error) {
+) (ip netip.Addr, ttl time.Duration, err error) {
 	for i, resolver := range resolvers {
 		ip, ttl, err = xTransport.resolveUsingResolver(proto, host, resolver)
 		if err == nil {
@@ -324,16 +325,18 @@ func (xTransport *XTransport) resolveAndUpdateCache(host string) error {
 	if xTransport.proxyDialer != nil || xTransport.httpProxyFunction != nil {
 		return nil
 	}
-	if ParseIP(host) != nil {
+	_, err := ParseIP(host)
+	if err != nil {
 		return nil
 	}
+
 	cachedIP, expired := xTransport.loadCachedIP(host)
-	if cachedIP != nil && !expired {
+	if cachedIP != netip.IPv4Unspecified() && !expired {
 		return nil
 	}
-	var foundIP net.IP
+	var foundIP netip.Addr
 	var ttl time.Duration
-	var err error
+
 	if !xTransport.ignoreSystemDNS {
 		foundIP, ttl, err = xTransport.resolveUsingSystem(host)
 	}
@@ -366,7 +369,7 @@ func (xTransport *XTransport) resolveAndUpdateCache(host string) error {
 		ttl = MinResolverIPTTL
 	}
 	if err != nil {
-		if cachedIP != nil {
+		if cachedIP != netip.IPv4Unspecified() {
 			dlog.Noticef("Using stale [%v] cached address for a grace period", host)
 			foundIP = cachedIP
 			ttl = ExpiredCachedIPGraceTTL


### PR DESCRIPTION
@jedisct1 
First step towards converting dnscrypt to use netip.Addr in place of net.IP.   I'm hoping we'll see some efficiency gains as the objects are tighter.   The original article is here https://tailscale.com/blog/netaddr-new-ip-type-for-go/  and has now been adopted into the 'netip' package.
I've just tackled the xtransport layer for now - if you're happy with the swap, then I'll start on the plugins and other areas.
I don't see signs of miekg updating the dns package to netip, but maybe the V2 he's working on might... 

One specific thing to bring your attention to in `xtransport.go`, lines `276` and `296`.  This is the `miekg/dns -> dnscrypt` interface:
The original code assumes, that if there are answers, then the 'IP' returned in the answer will be used (no nil checks).
I've continued with that assumption, and don't check for an err object parsing the result; happy to discuss.
