### PR TITLE
Adopt expired cache sources while downloading the latest

### DIFF
--- a/dnscrypt-proxy/sources.go
+++ b/dnscrypt-proxy/sources.go
@@ -222,8 +222,8 @@ func NewSource(
 
 // PrefetchSources downloads latest versions of given sources, ensuring they have a valid signature before caching
 func PrefetchSources(xTransport *XTransport, sources []*Source) (time.Duration, int) {
+	var interval time.Duration
 	now := timeNow()
-	interval := MinimumPrefetchInterval
 	downloaded := 0
 	for _, source := range sources {
 		var delay time.Duration
@@ -241,9 +241,13 @@ func PrefetchSources(xTransport *XTransport, sources []*Source) (time.Duration, 
 				downloaded++
 			}
 		}
-		if delay >= MinimumPrefetchInterval && (interval == MinimumPrefetchInterval || interval > delay) {
+		if interval == 0 || interval > delay {
 			interval = delay
 		}
+	}
+	if interval < MinimumPrefetchInterval {
+		dlog.Debugf("Prefetching delay %v is ceiled to %v", interval, MinimumPrefetchInterval)
+		interval = MinimumPrefetchInterval
 	}
 	return interval, downloaded
 }

--- a/dnscrypt-proxy/sources_test.go
+++ b/dnscrypt-proxy/sources_test.go
@@ -458,12 +458,15 @@ func TestPrefetchSources(t *testing.T) {
 	teardown, d := setupSourceTest(t)
 	defer teardown()
 	checkResult := func(t *testing.T, expects []*SourceTestExpect, got time.Duration) {
+		var expectDelay time.Duration
 		c := check.T(t)
-		expectDelay := MinimumPrefetchInterval
 		for _, e := range expects {
-			if e.delay >= MinimumPrefetchInterval && (expectDelay == MinimumPrefetchInterval || expectDelay > e.delay) {
+			if expectDelay == 0 || expectDelay > e.delay {
 				expectDelay = e.delay
 			}
+		}
+		if expectDelay < MinimumPrefetchInterval {
+			expectDelay = MinimumPrefetchInterval
 		}
 		c.InDelta(got, expectDelay, time.Second, "Unexpected return")
 		checkTestServer(c, d)


### PR DESCRIPTION
It is some kind of Series to Parallel.

Here we treat expired as correct and needing to be updated ASAP,
try it immediately instead of as a fallback. No hard expired concept.

Normally, most stamps are still available. Stamps shouldn't change too
frequently for convenience.

It improves user experiences for those who has downloading disfluency:
valid server is at the last, none at all, or QoS deterioration (< 10 K/s).
