### PR TITLE
Adopt `refresh_delay`s as cache sources TTL

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -878,8 +878,8 @@ func (config *Config) loadSource(proxy *Proxy, cfgSourceName string, cfgSource *
 	if cfgSource.FormatStr == "" {
 		cfgSource.FormatStr = "v2"
 	}
-	if cfgSource.RefreshDelay <= 0 {
-		cfgSource.RefreshDelay = 72
+	if cfgSource.RefreshDelay < 24 {
+		cfgSource.RefreshDelay = 24
 	} else if cfgSource.RefreshDelay > 168 {
 		cfgSource.RefreshDelay = 168
 	}

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -677,9 +677,9 @@ format = 'tsv'
 ## If the `urls` property is missing, cache files and valid signatures
 ## must already be present. This doesn't prevent these cache files from
 ## expiring after `refresh_delay` hours.
-## Cache freshness is checked every 24 hours, so values for 'refresh_delay'
-## of less than 24 hours will have no effect.
-## A maximum delay of 168 hours (1 week) is imposed to ensure cache freshness.
+## `refresh_delay` is neared to integer in [24, 168].
+## The minimum delay of 24 hours (1 day) is imposed to ensure efficiency.
+## The maximum delay of 168 hours (1 week) is imposed to ensure cache freshness.
 
 [sources]
 

--- a/dnscrypt-proxy/sources_test.go
+++ b/dnscrypt-proxy/sources_test.go
@@ -42,6 +42,8 @@ const (
 	TestStatePathErr                           // unparseable path to files (download only)
 )
 
+const DefaultPrefetchDelay time.Duration = 24 * time.Hour
+
 type SourceTestData struct {
 	n                         int // subtest counter
 	xTransport                *XTransport
@@ -350,7 +352,7 @@ func prepSourceTestDownload(
 	}
 	if e.success {
 		e.err = ""
-		e.delay = DefaultPrefetchDelay
+		e.delay = e.Source.cacheTTL
 	} else {
 		e.delay = MinimumPrefetchInterval
 	}
@@ -371,7 +373,7 @@ func setupSourceTestCase(t *testing.T, d *SourceTestData, i int,
 	}
 	e.Source = &Source{
 		name: id, urls: []*url.URL{}, format: SourceFormatV2, minisignKey: d.key,
-		cacheFile: e.cachePath, cacheTTL: DefaultPrefetchDelay * 3, prefetchDelay: DefaultPrefetchDelay,
+		cacheFile: e.cachePath, cacheTTL: DefaultPrefetchDelay * 3,
 	}
 	if cacheTest != nil {
 		prepSourceTestCache(t, d, e, d.sources[i], *cacheTest)
@@ -405,9 +407,9 @@ func TestNewSource(t *testing.T) {
 		refreshDelay time.Duration
 		e            *SourceTestExpect
 	}{
-		{"", "", 0, &SourceTestExpect{err: " ", Source: &Source{name: "short refresh delay", urls: []*url.URL{}, cacheTTL: DefaultPrefetchDelay, prefetchDelay: DefaultPrefetchDelay, prefix: ""}}},
-		{"v1", d.keyStr, DefaultPrefetchDelay * 2, &SourceTestExpect{err: "Unsupported source format", Source: &Source{name: "old format", urls: []*url.URL{}, cacheTTL: DefaultPrefetchDelay * 2, prefetchDelay: DefaultPrefetchDelay}}},
-		{"v2", "", DefaultPrefetchDelay * 3, &SourceTestExpect{err: "Invalid encoded public key", Source: &Source{name: "invalid public key", urls: []*url.URL{}, cacheTTL: DefaultPrefetchDelay * 3, prefetchDelay: DefaultPrefetchDelay}}},
+		{"", "", DefaultPrefetchDelay, &SourceTestExpect{err: " ", Source: &Source{name: "short refresh delay", urls: []*url.URL{}, cacheTTL: DefaultPrefetchDelay, prefix: ""}}},
+		{"v1", d.keyStr, DefaultPrefetchDelay * 2, &SourceTestExpect{err: "Unsupported source format", Source: &Source{name: "old format", urls: []*url.URL{}, cacheTTL: DefaultPrefetchDelay * 2}}},
+		{"v2", "", DefaultPrefetchDelay * 3, &SourceTestExpect{err: "Invalid encoded public key", Source: &Source{name: "invalid public key", urls: []*url.URL{}, cacheTTL: DefaultPrefetchDelay * 3}}},
 	} {
 		t.Run(tt.e.Source.name, func(t *testing.T) {
 			got, err := NewSource(
@@ -478,6 +480,7 @@ func TestPrefetchSources(t *testing.T) {
 			s := &Source{}
 			*s = *e.Source
 			s.in = nil
+			s.refresh = d.timeNow
 			sources = append(sources, s)
 			expects = append(expects, e)
 		}


### PR DESCRIPTION
`refresh_delay` was limited to `[1, 168]`, while `source.prefetchDelay` is 24 which controlled downloading.

That makes `refresh_delay` less effective.
`[1, 24)` triggers reparsing cache sources but no downloading, `(24, 168]` is defeated by `source.prefetchDelay` but says still fresh. In other words, value which is non-integer times of 24 is ceiled, and downloading always happen every 24h if there is no failure triggers retry.

The process flow was complicated and puzzling. Plus there could be multiple `refresh_delay`s.

Now, both downloading and reparsing are ruled by `refresh_delay`, `prefetchDelay` is obsoleted. It gives user sense of mastery, with tutelage.

---
More explains:

The delay algorithm of source downloading and reparsing is very complicated and puzzling.
Here are my understandings:
Workflow
![delay](https://user-images.githubusercontent.com/19585474/220896116-e869715a-eca0-4a77-9e50-d9bdb0c7df4b.png)
Delay
![sleep](https://user-images.githubusercontent.com/19585474/220896277-2f851153-d913-4231-ae93-69fc8c899a1b.png)

Different `refresh_delay`s of sources make things more complicated. Here are some key rules:
1. `prefetchDelay` always controls the downloading, if no failure. At startup, `refresh_delay` doesn’t determine delay at all. If the cache expired, then the delay depends on the downloading result. If the cache isn’t expired, ` delay = source.prefetchDelay - elapsed`.
2. `refresh_delay` is only effective at startup or on out-of-step sources, when it `< prefetchDelay` and the cache is expired at startup. When it `> prefetchDelay`, `source.prefetchDelay - elapsed` is smaller. So, if the cache elapsed between them, program will say the cache is fresh but still is going to download the files, and then sleep depending on the result. `refresh_delay` doesn’t produce the delay too, when the flow starts from `PrefetchSources`.
3. Any cache delay remain time is ceiled to prefetchDelay. Those `refresh_delay > prefetchDelay`, but is not `N * prefetchDelay`, the `refresh_delay % prefetchDelay` will be ceiled to prefetchDelay. And `refresh_delay < prefetchDelay` too. It makes `refresh_delay` slightly meaningless. And, at startup, the worst case delay is approximately `2 * prefetchDelay`.

In summary, `refresh_delay` is less effective and makes things puzzling. Adopting `refresh_delay` as the real delay will make things simple and give user sense of mastery.
