### PR TITLE
CI: Don't downloading already vendored dependencies

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Test suite
         run: |
           go version
-          go mod vendor
           cd .ci
           ./ci-test.sh
           cd -


### PR DESCRIPTION
Checked the origin, but still don't know why this is added. Hope I didn't miss anything.