### PR TITLE
Balance multiple stamps with the same name

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -297,6 +297,10 @@ func (proxy *Proxy) updateRegisteredServers() error {
 				len(registeredServers),
 			)
 		}
+		// Balance multiple stamps with the same name
+		rand.Shuffle(len(registeredServers), func(i, j int) {
+			registeredServers[i], registeredServers[j] = registeredServers[j], registeredServers[i]
+		})
 		for _, registeredServer := range registeredServers {
 			if registeredServer.stamp.Proto != stamps.StampProtoTypeDNSCryptRelay &&
 				registeredServer.stamp.Proto != stamps.StampProtoTypeODoHRelay {


### PR DESCRIPTION
It used to replace the old one with the 1st new found. That is rotating between the first two.
https://github.com/DNSCrypt/dnscrypt-proxy/discussions/2422
