### PR TITLE
Add note regarding block_unqualified setting

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -348,6 +348,7 @@ block_ipv6 = false
 
 
 ## Immediately respond to A and AAAA queries for host names without a domain name
+## This also prevents "dotless domain names" from being resolved upstream.
 
 block_unqualified = true
 


### PR DESCRIPTION
As a reminder that, when `block_unqualified` is enabled, queries for [dotless domain names](https://features.icann.org/dotless-domains) such as [`ai`](http://ai/) and [`pn`](http://pn/) (those with webpages are rare in the global Internet) will be considered as unqualified and hence not be forwarded to upstream resolvers, failing to resolve by default.