### PR TITLE
Don't assume IPv4 and IPv6 for DoH servers

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -313,9 +313,6 @@ func (proxy *Proxy) updateRegisteredServers() error {
 			}
 			if proxy.SourceIPv4 || proxy.SourceIPv6 {
 				isIPv4, isIPv6 := true, false
-				if registeredServer.stamp.Proto == stamps.StampProtoTypeDoH {
-					isIPv4, isIPv6 = true, true
-				}
 				if strings.HasPrefix(registeredServer.stamp.ServerAddrStr, "[") {
 					isIPv4, isIPv6 = false, true
 				}


### PR DESCRIPTION
Commit 22f69a4 assumes every DoH server has both IPv4 & IPv6, thus rendering config option `ipv4_servers = false` useless with DoH servers.

Here is the log of filtered servers with the option `ipv4_servers` set to `false`:

<details><summary>Before the patch</summary>
<p>

```
[NOTICE] -    40ms cloudflare-ipv6
[NOTICE] -    41ms quad9-doh-ip6-port5053-nofilter-pri
[NOTICE] -    66ms quad9-doh-ip6-port443-nofilter-pri
[NOTICE] -    88ms controld-unfiltered
[NOTICE] -    93ms libredns
[NOTICE] -    97ms cloudflare
[NOTICE] -   100ms quad9-doh-ip4-port443-nofilter-pri
[NOTICE] -   101ms controld-uncensored
[NOTICE] -   106ms uncensoreddns-ipv6
[NOTICE] -   109ms dns.sb
[NOTICE] -   111ms adguard-dns-unfiltered-doh
[NOTICE] -   112ms meganerd-doh-ipv4
[NOTICE] -   113ms meganerd-doh-ipv6
[NOTICE] -   115ms nextdns-ipv6
[NOTICE] -   116ms nextdns-ultralow
[NOTICE] -   117ms nextdns
[NOTICE] -   117ms ams-doh-nl-ipv6
[NOTICE] -   118ms bortzmeyer
[NOTICE] -   119ms doh-ibksturm
[NOTICE] -   119ms uncensoreddns-ipv4
[NOTICE] -   126ms uncensoreddns-dk-ipv6
[NOTICE] -   129ms njalla-doh
[NOTICE] -   131ms circl-doh-ipv6
[NOTICE] -   134ms dns.digitale-gesellschaft.ch
[NOTICE] -   137ms dns.digitalsize.net-ipv6
[NOTICE] -   145ms doh.appliedprivacy.net
[NOTICE] -   147ms uncensoreddns-dk-ipv4
[NOTICE] -   179ms dnscrypt.ca-1-doh
[NOTICE] -   202ms quad9-doh-ip4-port5053-nofilter-pri
[NOTICE] -   217ms dnscrypt.ca-2-doh-ipv6
[NOTICE] -   223ms plan9dns-nj-doh
[NOTICE] -   238ms dnscrypt.ca-2-doh
[NOTICE] -   252ms doh.ffmuc.net-v6-2
[NOTICE] -   276ms doh.ffmuc.net-2
[NOTICE] -   280ms doh.ffmuc.net
[NOTICE] -   316ms plan9dns-nj-doh-ipv6
[NOTICE] -   320ms plan9dns-mx-doh-ipv6
[NOTICE] -   366ms dnscrypt.ca-1-doh-ipv6
[NOTICE] -   391ms doh-crypto-sx
[NOTICE] -   406ms plan9dns-mx-doh
[NOTICE] -   437ms plan9dns-fl-doh
[NOTICE] -   466ms ams-doh-nl
[NOTICE] -   493ms sby-doh-limotelu
[NOTICE] -   500ms doh.ffmuc.net-v6
[NOTICE] -   552ms publicarray-au2-doh
[NOTICE] -   615ms jp.tiar.app-doh-ipv6
[NOTICE] -   656ms sth-doh-se
[NOTICE] -  1141ms jp.tiarap.org-ipv6
[NOTICE] -  1159ms quad9-doh-ip6-port443-nofilter-ecs-pri
[NOTICE] -  1294ms quad9-doh-ip4-port5053-nofilter-ecs-pri
[NOTICE] -  2199ms quad9-doh-ip4-port443-nofilter-ecs-pri
[NOTICE] -  2218ms quad9-doh-ip6-port5053-nofilter-ecs-pri
[NOTICE] -  2253ms jp.tiarap.org
```

</p>
</details> 

<details><summary>After the patch</summary>
<p>

```
[NOTICE] -    81ms cloudflare-ipv6
[NOTICE] -    87ms quad9-doh-ip6-port443-nofilter-pri
[NOTICE] -   104ms quad9-doh-ip6-port5053-nofilter-pri
[NOTICE] -   129ms nextdns-ipv6
[NOTICE] -   139ms uncensoreddns-ipv6
[NOTICE] -   143ms dns.digitalsize.net-ipv6
[NOTICE] -   151ms meganerd-doh-ipv6
[NOTICE] -   173ms quad9-doh-ip6-port5053-nofilter-ecs-pri
[NOTICE] -   180ms circl-doh-ipv6
[NOTICE] -   196ms dnscrypt.ca-2-doh-ipv6
[NOTICE] -   206ms bortzmeyer-ipv6
[NOTICE] -   251ms dns.digitale-gesellschaft.ch-ipv6
[NOTICE] -   256ms uncensoreddns-dk-ipv6
[NOTICE] -   278ms plan9dns-mx-doh-ipv6
[NOTICE] -   280ms doh.ffmuc.net-v6
[NOTICE] -   286ms quad9-doh-ip6-port443-nofilter-ecs-pri
[NOTICE] -   355ms plan9dns-fl-doh-ipv6
[NOTICE] -   429ms ams-doh-nl-ipv6
[NOTICE] -   519ms plan9dns-nj-doh-ipv6
[NOTICE] -   527ms dnscrypt.ca-1-doh-ipv6
[NOTICE] -   615ms jp.tiar.app-doh-ipv6
[NOTICE] -   816ms doh.ffmuc.net-v6-2
[NOTICE] -  1281ms jp.tiarap.org-ipv6
```

</p>
</details> 