### PR TITLE
Configured Github CI to always use latest go version

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1
+          check-latest: true
         id: go
 
       - name: Test suite


### PR DESCRIPTION
* Check if there is a newer version of go before using the cached version.