### PR TITLE
Support server refresh concurrency

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	Timeout                  int            `toml:"timeout"`
 	KeepAlive                int            `toml:"keepalive"`
 	Proxy                    string         `toml:"proxy"`
+	CertRefreshConcurrency   int            `toml:"cert_refresh_concurrency"`
 	CertRefreshDelay         int            `toml:"cert_refresh_delay"`
 	CertIgnoreTimestamp      bool           `toml:"cert_ignore_timestamp"`
 	EphemeralKeys            bool           `toml:"dnscrypt_ephemeral_keys"`
@@ -116,6 +117,7 @@ func newConfig() Config {
 		LocalDoH:                 LocalDoHConfig{Path: "/dns-query"},
 		Timeout:                  5000,
 		KeepAlive:                5,
+		CertRefreshConcurrency:   10,
 		CertRefreshDelay:         240,
 		HTTP3:                    false,
 		CertIgnoreTimestamp:      false,
@@ -437,6 +439,7 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	if config.ForceTCP {
 		proxy.mainProto = "tcp"
 	}
+	proxy.certRefreshConcurrency = Max(1, config.CertRefreshConcurrency)
 	proxy.certRefreshDelay = time.Duration(Max(60, config.CertRefreshDelay)) * time.Minute
 	proxy.certRefreshDelayAfterFailure = time.Duration(10 * time.Second)
 	proxy.certIgnoreTimestamp = config.CertIgnoreTimestamp

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -183,6 +183,12 @@ keepalive = 30
 # use_syslog = true
 
 
+## The maximum concurrency to reload certificates from the resolvers.
+## Default is 10.
+
+# cert_refresh_concurrency = 10
+
+
 ## Delay, in minutes, after which certificates are reloaded
 
 cert_refresh_delay = 240

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -74,6 +74,7 @@ type Proxy struct {
 	certRefreshDelayAfterFailure  time.Duration
 	timeout                       time.Duration
 	certRefreshDelay              time.Duration
+	certRefreshConcurrency        int
 	cacheSize                     int
 	logMaxBackups                 int
 	logMaxAge                     int

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -249,21 +249,20 @@ func (serversInfo *ServersInfo) refresh(proxy *Proxy) (int, error) {
 	sort.SliceStable(serversInfo.inner, func(i, j int) bool {
 		return serversInfo.inner[i].initialRtt < serversInfo.inner[j].initialRtt
 	})
+	serversInfo.Unlock()
+
+	serversInfo.RLock()
 	inner := serversInfo.inner
 	innerLen := len(inner)
-	if innerLen > 1 {
+	if innerLen > 0 {
 		dlog.Notice("Sorted latencies:")
 		for i := 0; i < innerLen; i++ {
 			dlog.Noticef("- %5dms %s", inner[i].initialRtt, inner[i].Name)
 		}
-	}
-	if innerLen > 0 {
 		dlog.Noticef("Server with the lowest initial latency: %s (rtt: %dms)", inner[0].Name, inner[0].initialRtt)
-	}
-	serversInfo.Unlock()
-	if innerLen > 0 {
 		err = nil
 	}
+	serversInfo.RUnlock()
 	return innerLen, err
 }
 

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -249,20 +249,21 @@ func (serversInfo *ServersInfo) refresh(proxy *Proxy) (int, error) {
 	sort.SliceStable(serversInfo.inner, func(i, j int) bool {
 		return serversInfo.inner[i].initialRtt < serversInfo.inner[j].initialRtt
 	})
-	serversInfo.Unlock()
-
-	serversInfo.RLock()
 	inner := serversInfo.inner
 	innerLen := len(inner)
-	if innerLen > 0 {
+	if innerLen > 1 {
 		dlog.Notice("Sorted latencies:")
 		for i := 0; i < innerLen; i++ {
 			dlog.Noticef("- %5dms %s", inner[i].initialRtt, inner[i].Name)
 		}
+	}
+	if innerLen > 0 {
 		dlog.Noticef("Server with the lowest initial latency: %s (rtt: %dms)", inner[0].Name, inner[0].initialRtt)
+	}
+	serversInfo.Unlock()
+	if innerLen > 0 {
 		err = nil
 	}
-	serversInfo.RUnlock()
 	return innerLen, err
 }
 

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -228,12 +228,10 @@ func (serversInfo *ServersInfo) refresh(proxy *Proxy) (int, error) {
 	copy(registeredServers, serversInfo.registeredServers)
 	serversInfo.RUnlock()
 
-	// Always have proxy.certRefreshConcurrency servers being refreshed in parallel
 	countChannel := make(chan struct{}, proxy.certRefreshConcurrency)
 	waitChannel := make(chan struct{})
 	var err error
 	for i := range registeredServers {
-		// Would block if countChannel is already filled
 		countChannel <- struct{}{}
 		go func(registeredServer *RegisteredServer) {
 			if err = serversInfo.refreshServer(proxy, registeredServer.name, registeredServer.stamp); err == nil {

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -245,7 +245,9 @@ func (serversInfo *ServersInfo) refresh(proxy *Proxy) (int, error) {
 			}
 		}(&registeredServers[i])
 	}
-	<-waitChannel
+	if len(registeredServers) > 0 {
+		<-waitChannel
+	}
 	serversInfo.Lock()
 	sort.SliceStable(serversInfo.inner, func(i, j int) bool {
 		return serversInfo.inner[i].initialRtt < serversInfo.inner[j].initialRtt


### PR DESCRIPTION
We can simultaneously refresh all servers instead of refresh them one by one, which can greatly improve startup speed without visible loss of accuracy