### PR TITLE
add timeout for udp and tcp dialer

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -517,7 +517,7 @@ func (proxy *Proxy) exchangeWithUDPServer(
 	var pc net.Conn
 	proxyDialer := proxy.xTransport.proxyDialer
 	if proxyDialer == nil {
-		pc, err = net.DialUDP("udp", nil, upstreamAddr)
+		pc, err = net.DialTimeout("udp", upstreamAddr.String(), serverInfo.Timeout)
 	} else {
 		pc, err = (*proxyDialer).Dial("udp", upstreamAddr.String())
 	}
@@ -560,7 +560,7 @@ func (proxy *Proxy) exchangeWithTCPServer(
 	var pc net.Conn
 	proxyDialer := proxy.xTransport.proxyDialer
 	if proxyDialer == nil {
-		pc, err = net.DialTCP("tcp", nil, upstreamAddr)
+		pc, err = net.DialTimeout("tcp", upstreamAddr.String(), serverInfo.Timeout)
 	} else {
 		pc, err = (*proxyDialer).Dial("tcp", upstreamAddr.String())
 	}


### PR DESCRIPTION
The timeout can be set in the configuration file for the i/o timeout situation, so that sending and receiving DNS will end within a limited time. 
However, recently I found that  **_sometimes DNS resolution will block for significantly longer than the timeout_**, all block for **_more than two minutes_**.
The details is, when requesting certain relays which are not responding to the connection issued from the proxy, **_connection timeout will appear instead of i/o timeout_.** The timeout for connecting tcp is not set in the code. I haven't tried udp, I think they should all be configurable with timeouts.