### PR TITLE
Avoid infinite blocking

### DIFF
--- a/dnscrypt-proxy/coldstart.go
+++ b/dnscrypt-proxy/coldstart.go
@@ -23,7 +23,9 @@ type CaptivePortalHandler struct {
 
 func (captivePortalHandler *CaptivePortalHandler) Stop() {
 	close(captivePortalHandler.cancelChannel)
-	<-captivePortalHandler.waitChannel
+	if captivePortalHandler.channelCount > 0 {
+		<-captivePortalHandler.waitChannel
+	}
 	close(captivePortalHandler.countChannel)
 }
 


### PR DESCRIPTION
Follow up to 0d5e52bb.

In case of all `addColdStartListener` failed.
