### PR TITLE
Listen `0.0.0.0` only on IPv4

### DIFF
--- a/dnscrypt-proxy/coldstart.go
+++ b/dnscrypt-proxy/coldstart.go
@@ -122,11 +122,15 @@ func addColdStartListener(
 	listenAddrStr string,
 	captivePortalHandler *CaptivePortalHandler,
 ) error {
-	listenUDPAddr, err := net.ResolveUDPAddr("udp", listenAddrStr)
+	network := "udp"
+	if isDigit(listenAddrStr[0]) {
+		network = "udp4"
+	}
+	listenUDPAddr, err := net.ResolveUDPAddr(network, listenAddrStr)
 	if err != nil {
 		return err
 	}
-	clientPc, err := net.ListenUDP("udp", listenUDPAddr)
+	clientPc, err := net.ListenUDP(network, listenUDPAddr)
 	if err != nil {
 		return err
 	}

--- a/dnscrypt-proxy/common.go
+++ b/dnscrypt-proxy/common.go
@@ -166,6 +166,8 @@ func ReadTextFile(filename string) (string, error) {
 	return string(bin), nil
 }
 
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
 func maybeWritableByOtherUsers(p string) (bool, string, error) {
 	p = path.Clean(p)
 	for p != "/" && p != "." {

--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -274,8 +274,6 @@ func removeEDNS0Options(msg *dns.Msg) bool {
 	return true
 }
 
-func isDigit(b byte) bool { return b >= '0' && b <= '9' }
-
 func dddToByte(s []byte) byte {
 	return byte((s[0]-'0')*100 + (s[1]-'0')*10 + (s[2] - '0'))
 }

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -118,11 +118,17 @@ func (proxy *Proxy) registerLocalDoHListener(listener *net.TCPListener) {
 }
 
 func (proxy *Proxy) addDNSListener(listenAddrStr string) {
-	listenUDPAddr, err := net.ResolveUDPAddr("udp", listenAddrStr)
+	udp := "udp"
+	tcp := "tcp"
+	if isDigit(listenAddrStr[0]) {
+		udp = "udp4"
+		tcp = "tcp4"
+	}
+	listenUDPAddr, err := net.ResolveUDPAddr(udp, listenAddrStr)
 	if err != nil {
 		dlog.Fatal(err)
 	}
-	listenTCPAddr, err := net.ResolveTCPAddr("tcp", listenAddrStr)
+	listenTCPAddr, err := net.ResolveTCPAddr(tcp, listenAddrStr)
 	if err != nil {
 		dlog.Fatal(err)
 	}
@@ -141,11 +147,11 @@ func (proxy *Proxy) addDNSListener(listenAddrStr string) {
 	// if 'userName' is set and we are the parent process
 	if !proxy.child {
 		// parent
-		listenerUDP, err := net.ListenUDP("udp", listenUDPAddr)
+		listenerUDP, err := net.ListenUDP(udp, listenUDPAddr)
 		if err != nil {
 			dlog.Fatal(err)
 		}
-		listenerTCP, err := net.ListenTCP("tcp", listenTCPAddr)
+		listenerTCP, err := net.ListenTCP(tcp, listenTCPAddr)
 		if err != nil {
 			dlog.Fatal(err)
 		}
@@ -186,7 +192,11 @@ func (proxy *Proxy) addDNSListener(listenAddrStr string) {
 }
 
 func (proxy *Proxy) addLocalDoHListener(listenAddrStr string) {
-	listenTCPAddr, err := net.ResolveTCPAddr("tcp", listenAddrStr)
+	network := "tcp"
+	if isDigit(listenAddrStr[0]) {
+		network = "tcp4"
+	}
+	listenTCPAddr, err := net.ResolveTCPAddr(network, listenAddrStr)
 	if err != nil {
 		dlog.Fatal(err)
 	}
@@ -202,7 +212,7 @@ func (proxy *Proxy) addLocalDoHListener(listenAddrStr string) {
 	// if 'userName' is set and we are the parent process
 	if !proxy.child {
 		// parent
-		listenerTCP, err := net.ListenTCP("tcp", listenTCPAddr)
+		listenerTCP, err := net.ListenTCP(network, listenTCPAddr)
 		if err != nil {
 			dlog.Fatal(err)
 		}
@@ -442,7 +452,12 @@ func (proxy *Proxy) udpListenerFromAddr(listenAddr *net.UDPAddr) error {
 	if err != nil {
 		return err
 	}
-	clientPc, err := listenConfig.ListenPacket(context.Background(), "udp", listenAddr.String())
+	listenAddrStr := listenAddr.String()
+	network := "udp"
+	if isDigit(listenAddrStr[0]) {
+		network = "udp4"
+	}
+	clientPc, err := listenConfig.ListenPacket(context.Background(), network, listenAddrStr)
 	if err != nil {
 		return err
 	}
@@ -456,7 +471,12 @@ func (proxy *Proxy) tcpListenerFromAddr(listenAddr *net.TCPAddr) error {
 	if err != nil {
 		return err
 	}
-	acceptPc, err := listenConfig.Listen(context.Background(), "tcp", listenAddr.String())
+	listenAddrStr := listenAddr.String()
+	network := "tcp"
+	if isDigit(listenAddrStr[0]) {
+		network = "tcp4"
+	}
+	acceptPc, err := listenConfig.Listen(context.Background(), network, listenAddrStr)
 	if err != nil {
 		return err
 	}
@@ -470,7 +490,12 @@ func (proxy *Proxy) localDoHListenerFromAddr(listenAddr *net.TCPAddr) error {
 	if err != nil {
 		return err
 	}
-	acceptPc, err := listenConfig.Listen(context.Background(), "tcp", listenAddr.String())
+	listenAddrStr := listenAddr.String()
+	network := "tcp"
+	if isDigit(listenAddrStr[0]) {
+		network = "tcp4"
+	}
+	acceptPc, err := listenConfig.Listen(context.Background(), network, listenAddrStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For https://github.com/DNSCrypt/dnscrypt-proxy/blob/f5912d7ca99cd30213e89e865bee5da3e8c88266/dnscrypt-proxy/example-dnscrypt-proxy.toml#L39-L40

Maybe golang's behavior on this had changed some time ago.
Currently, listen to `0.0.0.0` will be on both IPv4 and IPv6 interfaces, the same as `::`.
https://github.com/golang/go/blob/9b4b3e5acca2dabe107fa2c3ed963097d78a4562/src/net/ipsock_posix.go#L129