### PR TITLE
CI tests the unregistered domain for solid NS answer

### DIFF
--- a/.ci/ci-test.sh
+++ b/.ci/ci-test.sh
@@ -66,11 +66,11 @@ t || dig -p${DNS_PORT} +dnssec darpa.mil @127.0.0.1 2>&1 | grep -Fvq 'RRSIG' || 
 t || dig -p${DNS_PORT} +dnssec www.darpa.mil @127.0.0.1 2>&1 | grep -Fvq 'RRSIG' || fail
 
 section
-t || dig -p${DNS_PORT} +short cloaked.com @127.0.0.1 | grep -Eq '1.1.1.1|1.0.0.1' || fail
-t || dig -p${DNS_PORT} +short MX cloaked.com @127.0.0.1 | grep -Fq 'locally blocked' || fail
+t || dig -p${DNS_PORT} +short cloakedunregistered.com @127.0.0.1 | grep -Eq '1.1.1.1|1.0.0.1' || fail
+t || dig -p${DNS_PORT} +short MX cloakedunregistered.com @127.0.0.1 | grep -Fq 'locally blocked' || fail
 t || dig -p${DNS_PORT} +short MX example.com @127.0.0.1 | grep -Fvq 'locally blocked' || fail
-t || dig -p${DNS_PORT} NS cloaked.com @127.0.0.1 | grep -Fiq 'gtld-servers.net' || fail
-t || dig -p${DNS_PORT} +short www.cloaked2.com @127.0.0.1 | grep -Eq '1.1.1.1|1.0.0.1' || fail
+t || dig -p${DNS_PORT} NS cloakedunregistered.com @127.0.0.1 | grep -Fiq 'gtld-servers.net' || fail
+t || dig -p${DNS_PORT} +short www.cloakedunregistered2.com @127.0.0.1 | grep -Eq '1.1.1.1|1.0.0.1' || fail
 t || dig -p${DNS_PORT} +short www.dnscrypt-test @127.0.0.1 | grep -Fq '192.168.100.100' || fail
 t || dig -p${DNS_PORT} a.www.dnscrypt-test @127.0.0.1 | grep -Fq 'NXDOMAIN' || fail
 t || dig -p${DNS_PORT} +short ptr 101.100.168.192.in-addr.arpa. @127.0.0.1 | grep -Eq 'www.dnscrypt-test.com' || fail
@@ -122,8 +122,8 @@ t || grep -Eq 'invalid.*SYNTH' query.log || fail
 t || grep -Eq '168.192.in-addr.arpa.*SYNTH' query.log || fail
 t || grep -Eq 'darpa.mil.*FORWARD' query.log || fail
 t || grep -Eq 'www.darpa.mil.*FORWARD' query.log || fail
-t || grep -Eq 'cloaked.com.*CLOAK' query.log || fail
-t || grep -Eq 'www.cloaked2.com.*CLOAK' query.log || fail
+t || grep -Eq 'cloakedunregistered.com.*CLOAK' query.log || fail
+t || grep -Eq 'www.cloakedunregistered2.com.*CLOAK' query.log || fail
 t || grep -Eq 'www.dnscrypt-test.*CLOAK' query.log || fail
 t || grep -Eq 'a.www.dnscrypt-test.*NXDOMAIN' query.log || fail
 t || grep -Eq 'telemetry.example.*REJECT' query.log || fail

--- a/.ci/cloaking-rules.txt
+++ b/.ci/cloaking-rules.txt
@@ -1,5 +1,5 @@
-cloaked.*                one.one.one.one
-*.cloaked2.*             one.one.one.one # inline comment
-=www.dnscrypt-test       192.168.100.100
-=www.dnscrypt-test.com   192.168.100.101
-=ipv6.dnscrypt-test.com  fd02::1
+cloakedunregistered.*       one.one.one.one
+*.cloakedunregistered2.*    one.one.one.one # inline comment
+=www.dnscrypt-test          192.168.100.100
+=www.dnscrypt-test.com      192.168.100.101
+=ipv6.dnscrypt-test.com     fd02::1

--- a/.ci/test3-dnscrypt-proxy.toml
+++ b/.ci/test3-dnscrypt-proxy.toml
@@ -13,8 +13,6 @@ cache = true
 [query_log]
 file = 'query.log'
 
-
-
 [static]
 
   [static.'myserver']


### PR DESCRIPTION
And formats.

Fix [test #20 failure](https://github.com/DNSCrypt/dnscrypt-proxy/actions/runs/7577050919/job/20637111582#step:5:78).
The `cloaked.com` is owned by somebody, and its Name Servers will be changed by their willing.