### PR TITLE
fix go version format

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,11 @@ jobs:
       with:
         fetch-depth: 2
 
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dnscrypt/dnscrypt-proxy
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
I was looking into why the build is failing. I'm not sure why the odoh tests are failing, but I think the CodeQL failure is because go version incorrectly has `.0` appended.