### PR TITLE
Forwarding plugin: Support forwarding subdomains of the root domain

### DIFF
--- a/dnscrypt-proxy/plugin_forward.go
+++ b/dnscrypt-proxy/plugin_forward.go
@@ -89,8 +89,9 @@ func (plugin *PluginForward) Eval(pluginsState *PluginsState, msg *dns.Msg) erro
 		if candidateLen > qNameLen {
 			continue
 		}
-		if qName[qNameLen-candidateLen:] == candidate.domain &&
-			(candidateLen == qNameLen || (qName[qNameLen-candidateLen-1] == '.')) {
+		if (qName[qNameLen-candidateLen:] == candidate.domain &&
+			(candidateLen == qNameLen || (qName[qNameLen-candidateLen-1] == '.'))) ||
+			(candidate.domain == ".") {
 			servers = candidate.servers
 			break
 		}


### PR DESCRIPTION
This commit updates the forwarding plugin to support matching subdomains of the root domain ("."). It looks like the forwarding plugin already performs subdomain matches against the domains specified in the forwarding rules files, but matches against the root domain weren't working because of the way matches are performed by comparing the normalized presentation format QNAME (which omits the trailing dot for all QNAMEs except the root domain name).

Without this commit, only queries where the QNAME is exactly "." would match a forwarding rule for the "." domain, like this (with `offline_mode = true` and a single forwarding rule for the "." domain):

```
[2024-03-25 21:13:31]	100.100.100.100	.	NS	FORWARD	0ms	127.0.0.1:53
[2024-03-25 21:13:36]	100.100.100.100	com	NS	NOT_READY	0ms	-
```

With this commit I get the expected result:

```
[2024-03-25 21:40:07]	100.100.100.100	.	NS	FORWARD	0ms	127.0.0.1:53
[2024-03-25 21:40:09]	100.100.100.100	com	NS	FORWARD	0ms	127.0.0.1:53
```