### PR TITLE
Cipher Suite and Start up fixes

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -959,6 +959,8 @@ func (config *Config) loadSource(proxy *Proxy, cfgSourceName string, cfgSource *
 		dlog.Infof("Downloading [%s] failed: %v, using cache file to startup", source.name, err)
 	}
 	proxy.sources = append(proxy.sources, source)
+	proxy.xTransport.keepCipherSuite = true
+	proxy.xTransport.rebuildTransport()
 	return nil
 }
 

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -229,9 +229,19 @@ func (xTransport *XTransport) rebuildTransport() {
 	if xTransport.tlsCipherSuite != nil {
 		tlsClientConfig.PreferServerCipherSuites = false
 		tlsClientConfig.MaxVersion = tls.VersionTLS13
-		if xTransport.keepCipherSuite == true {
+		var tls13 = "198 199 4865 4866 4867 4868 4869 49332 49333"
+		var only13 = 0
+		var SuitesCount = 0
+		for _, expectedSuiteID := range xTransport.tlsCipherSuite {
+			check := strconv.Itoa(int(expectedSuiteID))
+			if strings.Contains(tls13 , check) {
+				SuitesCount += 1
+			}
+			only13 += 1 
+		}
+		if xTransport.keepCipherSuite == true && only13 != SuitesCount {
 			tlsClientConfig.CipherSuites = xTransport.tlsCipherSuite
-			dlog.Infof("Explicit cipher suite %v configured downgrading TLS 1.2", xTransport.tlsCipherSuite)
+			dlog.Info("Explicit cipher suite configured downgrading to TLS 1.2")
 			tlsClientConfig.MaxVersion = tls.VersionTLS12
 			MinTry += 1
 		}

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -256,7 +256,6 @@ func (xTransport *XTransport) rebuildTransport() {
 	if http2Transport, err := http2.ConfigureTransports(transport); err != nil {
 		http2Transport.ReadIdleTimeout = timeout
 		http2Transport.AllowHTTP = false
-		xTransport.keepCipherSuite = true
 	}
 	xTransport.transport = transport
 	if xTransport.http3 {
@@ -567,9 +566,6 @@ func (xTransport *XTransport) Fetch(
 			dlog.Warnf(
 				"TLS handshake failure - Try changing or deleting the tls_cipher_suite value in the configuration file",
 			)
-			if xTransport.keepCipherSuite != true {
-				xTransport.tlsCipherSuite = nil
-			}
 			xTransport.rebuildTransport()
 		}
 		return nil, statusCode, nil, rtt, err

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -383,10 +383,8 @@ func (xTransport *XTransport) resolveUsingResolvers(
 	for i, resolver := range resolvers {
 		ip, ttl, err = xTransport.resolveUsingResolver(proto, host, resolver)
 		if err == nil {
-			if i > 0 {
-				dlog.Infof("Resolution succeeded with resolver %s[%s]", proto, resolver)
-				resolvers[0], resolvers[i] = resolvers[i], resolvers[0]
-			}
+			dlog.Infof("Resolution succeeded with resolver %s[%s]", proto, resolver)
+			resolvers[0], resolvers[i] = resolvers[i], resolvers[0]
 			break
 		}
 		dlog.Infof("Unable to resolve [%s] using resolver [%s] (%s): %v", host, resolver, proto, err)

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -226,8 +226,7 @@ func (xTransport *XTransport) rebuildTransport() {
 	}
 	if xTransport.tlsCipherSuite != nil {
 		tlsClientConfig.PreferServerCipherSuites = false
-		tlsClientConfig.CipherSuites = xTransport.tlsCipherSuite
-
+		tlsClientConfig.MaxVersion = tls.VersionTLS13
 		// Go doesn't allow changing the cipher suite with TLS 1.3
 		// So, check if the requested set of ciphers matches the TLS 1.3 suite.
 		// If it doesn't, downgrade to TLS 1.2
@@ -247,7 +246,8 @@ func (xTransport *XTransport) rebuildTransport() {
 				}
 			}
 		}
-		if compatibleSuitesCount != len(tls.CipherSuites()) {
+		if compatibleSuitesCount != len(tls.CipherSuites()) && xTransport.keepCipherSuite == true {
+			tlsClientConfig.CipherSuites = xTransport.tlsCipherSuite
 			dlog.Infof("Explicit cipher suite configured - downgrading to TLS 1.2 with cipher suite: %v", xTransport.tlsCipherSuite)
 			tlsClientConfig.MaxVersion = tls.VersionTLS12
 		}

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -414,23 +414,22 @@ func (xTransport *XTransport) resolveAndUpdateCache(host string) error {
 	if xTransport.mainProto == "tcp" {
 		protos = []string{"tcp", "udp"}
 	}
-	if xTransport.ignoreSystemDNS {
-		if xTransport.internalResolverReady {
-			for _, proto := range protos {
-				foundIP, ttl, err = xTransport.resolveUsingResolvers(proto, host, xTransport.internalResolvers)
-				if err == nil {
-					break
-				}
+	if xTransport.internalResolverReady {
+		for _, proto := range protos {
+			foundIP, ttl, err = xTransport.resolveUsingResolvers(proto, host, xTransport.internalResolvers)
+			if err == nil {
+				break
 			}
-		} else {
-			err = errors.New("Service is not usable yet")
-			dlog.Notice(err)
 		}
 	} else {
-		foundIP, ttl, err = xTransport.resolveUsingSystem(host)
-		if err != nil {
-			err = errors.New("System DNS is not usable yet")
-			dlog.Notice(err)
+		err = errors.New("Service is not usable yet")
+		dlog.Notice(err)
+		if xTransport.ignoreSystemDNS == false {
+			foundIP, ttl, err = xTransport.resolveUsingSystem(host)
+			if err != nil {
+				err = errors.New("System DNS is not usable yet")
+				dlog.Notice(err)
+			}
 		}
 	}
 	if err != nil {

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -220,9 +220,9 @@ func (xTransport *XTransport) rebuildTransport() {
 	}
 	if xTransport.tlsDisableSessionTickets {
 		tlsClientConfig.SessionTicketsDisabled = xTransport.tlsDisableSessionTickets
-		if !xTransport.tlsDisableSessionTickets {
-			tlsClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(10)
-		}
+		tlsClientConfig.ClientSessionCache = nil
+	} else {
+		tlsClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(10)
 	}
 	if xTransport.tlsCipherSuite != nil {
 		tlsClientConfig.PreferServerCipherSuites = false

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -226,8 +226,7 @@ func (xTransport *XTransport) rebuildTransport() {
 	} else {
 		tlsClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(10)
 	}
-	overrideCipherSuite := xTransport.tlsCipherSuite != nil && len(xTransport.tlsCipherSuite) > 0
-	if overrideCipherSuite != nil {
+	if xTransport.tlsCipherSuite != nil {
 		tlsClientConfig.PreferServerCipherSuites = false
 		tlsClientConfig.MaxVersion = tls.VersionTLS13
 		var tls13 = "198 199 4865 4866 4867 4868 4869 49332 49333"

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -226,7 +226,8 @@ func (xTransport *XTransport) rebuildTransport() {
 	} else {
 		tlsClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(10)
 	}
-	if xTransport.tlsCipherSuite != nil {
+	overrideCipherSuite := xTransport.tlsCipherSuite != nil && len(xTransport.tlsCipherSuite) > 0
+	if overrideCipherSuite != nil {
 		tlsClientConfig.PreferServerCipherSuites = false
 		tlsClientConfig.MaxVersion = tls.VersionTLS13
 		var tls13 = "198 199 4865 4866 4867 4868 4869 49332 49333"

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -443,7 +443,7 @@ func (xTransport *XTransport) resolveAndUpdateCache(host string) error {
 		dlog.Noticef("Bootstrap resolvers didn't respond - Trying with the system resolver as a last resort")
 		foundIP, ttl, err = xTransport.resolveUsingSystem(host)
 		if err != nil {
-			err = errors.New("System DNS is not usable yet")
+			err = errors.New("System DNS error")
 			dlog.Notice(err)
 		}	
 	}else if err != nil && xTransport.ignoreSystemDNS == true {

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -548,6 +548,10 @@ func (xTransport *XTransport) Fetch(
 	start := time.Now()
 	resp, err := client.Do(req)
 	rtt := time.Since(start)
+	statusCode := 503
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
 	if err == nil {
 		if resp == nil {
 			err = errors.New("Webserver returned an error")
@@ -557,18 +561,12 @@ func (xTransport *XTransport) Fetch(
 	} else {
 		dlog.Debugf("HTTP client error: [%v] - closing idle connections", err)
 		xTransport.transport.CloseIdleConnections()
-	}
-	statusCode := 503
-	if resp != nil {
-		statusCode = resp.StatusCode
-	}
-	if err != nil {
 		dlog.Debugf("[%s]: [%s]", req.URL, err)
 		if xTransport.tlsCipherSuite != nil && strings.Contains(err.Error(), "handshake failure") {
 			dlog.Warnf(
 				"TLS handshake failure - Try changing or deleting the tls_cipher_suite value in the configuration file",
 			)
-			xTransport.tlsCipherSuite = nil
+			//xTransport.tlsCipherSuite = nil
 			xTransport.rebuildTransport()
 		}
 		return nil, statusCode, nil, rtt, err

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -226,9 +226,7 @@ func (xTransport *XTransport) rebuildTransport() {
 	} else {
 		tlsClientConfig.ClientSessionCache = tls.NewLRUClientSessionCache(10)
 	}
-	if xTransport.tlsCipherSuite != nil {
-		tlsClientConfig.PreferServerCipherSuites = false
-		tlsClientConfig.MaxVersion = tls.VersionTLS13
+	if xTransport.tlsCipherSuite != nil && len(xTransport.tlsCipherSuite) > 0 && xTransport.keepCipherSuite == true {
 		var tls13 = "198 199 4865 4866 4867 4868 4869 49332 49333"
 		var only13 = 0
 		var SuitesCount = 0
@@ -239,12 +237,14 @@ func (xTransport *XTransport) rebuildTransport() {
 			}
 			only13 += 1 
 		}
-		if xTransport.keepCipherSuite == true && only13 != SuitesCount {
+		if only13 != SuitesCount {
 			tlsClientConfig.CipherSuites = xTransport.tlsCipherSuite
 			dlog.Info("Explicit cipher suite configured downgrading to TLS 1.2")
 			tlsClientConfig.MaxVersion = tls.VersionTLS12
 			MinTry += 1
 		}
+	} else {
+		tlsClientConfig.MaxVersion = tls.VersionTLS13
 	}
 	transport.TLSClientConfig = &tlsClientConfig
 	if http2Transport, err := http2.ConfigureTransports(transport); err != nil {


### PR DESCRIPTION
Please verify and merge this pull request.

I made some changes that will fix the selected things:

> Correctly use on xtrasport dnscrypt > fallback\bootstrat > system as it described on toml.

> From commit ca0f353087688865c1ee54d1ef3f3fb1ce2db748 and after if the cipher_suite is set and there is no source files the dnscrypt will fail to download it

> On start up the cipher suite will not use the selected cipher suite when source is present. I fixed that by changing the config to rebuildtrasnport with the selected cipher_suite when it finishes to fix the download on startup if there is no source and we have handshake issue.

> Some times on certificate refresh and other places that the rebuildtrasport may be called it will drop the cipher_suite to 4865. Now it will keep the selected cipher_suite

> Changed some messages and fixed a wrong error message

This error's created by setting the cipher suite to null.
Right now if the cipher suite is incorrect it won't connect but the other implementation dropped the cipher suite on refreshes to no PFS 4865. I think by default you can try to set for TLS 1.2 a more secure communication.
## 52393 = TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
## 52392 = TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
## 49249 = TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384
## 49200 = TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
## 49199 = TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
## 49196 = TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
## 49195 = TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256


There is one more thing that i haven't fixed. Gonna create an issue.
When no bootstarp resolver is specified in the file and you drop to deafult bootstrap, i think it is because of panic, it will panic before trying to create a connection with the second protocol if the first is blocked. 9.9.9.9 UDP no TCP panic but TCP 9.9.9.9 may be allowed. Double request on same protocol.
