### PR TITLE
Fix invalid documentation with DNSSEC in the example config file.

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -76,7 +76,7 @@ odoh_servers = false
 ## Require servers defined by remote sources to satisfy specific properties
 
 # Server must support DNS security extensions (DNSSEC)
-require_dnssec = false
+require_dnssec = true
 
 # Server must not log user queries (declarative)
 require_nolog = true


### PR DESCRIPTION
The comment says that server must support DNSSEC, but it sets require_dnssec = false 

I think require_dnssec needs to be set to true to require servers to support DNSSEC, and not the other way around.