### PR TITLE
Isolate dnscrypt-proxy Tor circuit

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -106,9 +106,13 @@ http3 = false
 
 ## SOCKS proxy
 ## Uncomment the following line to route all TCP connections to a local Tor node
-## Tor doesn't support UDP, so set `force_tcp` to `true` as well.
+## Tor doesn't support UDP, so set `force_tcp` to `true` as well. When passing
+## a random username and password to Tor's socks5 connection, dnscrypt-proxy gets
+## an isolated circuit so it will not share an exit node with other applications.
+## Note: the random username and password used by dnscrypt-proxy should not
+## actually be defined in Tor's configuration.
 
-# proxy = 'socks5://127.0.0.1:9050'
+# proxy = 'socks5://dnscrypt:dnscrypt@127.0.0.1:9050'
 
 
 ## HTTP/HTTPS proxy


### PR DESCRIPTION
Pass a random username and password to Tor's socks5 connection in order to isolate the circuit used by dnscrypt-proxy.

Proof of concept:

curl --connect-timeout 5 --ipv4 --socks5 test1:test1@127.0.0.1:9050 http://checkip.amazonaws.com
curl --connect-timeout 5 --ipv4 --socks5 test2:test2@127.0.0.1:9050 http://checkip.amazonaws.com

Switch between these two curl commands to show that the username defines the isolated circuit used by Tor.  This same technique is used by Tor Browser. 