### PR TITLE
Force the use of HTTPv3 with supplied hosts

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -39,6 +39,7 @@ type Config struct {
 	UserName                 string         `toml:"user_name"`
 	ForceTCP                 bool           `toml:"force_tcp"`
 	HTTP3                    bool           `toml:"http3"`
+	ForceHTTP3Hosts          []string       `toml:"force_http3_hosts"`
 	Timeout                  int            `toml:"timeout"`
 	KeepAlive                int            `toml:"keepalive"`
 	Proxy                    string         `toml:"proxy"`
@@ -120,6 +121,7 @@ func newConfig() Config {
 		CertRefreshConcurrency:   10,
 		CertRefreshDelay:         240,
 		HTTP3:                    false,
+		ForceHTTP3Hosts:          []string{},
 		CertIgnoreTimestamp:      false,
 		EphemeralKeys:            false,
 		Cache:                    true,
@@ -386,6 +388,14 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.xTransport.tlsCipherSuite = config.TLSCipherSuite
 	proxy.xTransport.mainProto = proxy.mainProto
 	proxy.xTransport.http3 = config.HTTP3
+	proxy.xTransport.http3SupportedHosts = make(map[string]bool)
+	if len(config.ForceHTTP3Hosts) > 0 {
+		for _, val := range config.ForceHTTP3Hosts {
+			if _, ok := proxy.xTransport.http3SupportedHosts[val]; !ok {
+				proxy.xTransport.http3SupportedHosts[val] = true
+			}
+		}
+	}
 	if len(config.BootstrapResolvers) == 0 && len(config.BootstrapResolversLegacy) > 0 {
 		dlog.Warnf("fallback_resolvers was renamed to bootstrap_resolvers - Please update your configuration")
 		config.BootstrapResolvers = config.BootstrapResolversLegacy

--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -388,11 +388,12 @@ func ConfigLoad(proxy *Proxy, flags *ConfigFlags) error {
 	proxy.xTransport.tlsCipherSuite = config.TLSCipherSuite
 	proxy.xTransport.mainProto = proxy.mainProto
 	proxy.xTransport.http3 = config.HTTP3
-	proxy.xTransport.http3SupportedHosts = make(map[string]bool)
+	proxy.xTransport.http3SupportedHosts = make(map[string]uint16)
 	if len(config.ForceHTTP3Hosts) > 0 {
 		for _, val := range config.ForceHTTP3Hosts {
 			if _, ok := proxy.xTransport.http3SupportedHosts[val]; !ok {
-				proxy.xTransport.http3SupportedHosts[val] = true
+				host, port := ExtractHostAndPort(val, 443)
+				proxy.xTransport.http3SupportedHosts[host] = uint16(port)
 			}
 		}
 	}

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -71,7 +71,7 @@ type XTransport struct {
 	useIPv4                  bool
 	useIPv6                  bool
 	http3                    bool
-	http3SupportedHosts      map[string]bool
+	http3SupportedHosts      map[string]uint16
 	tlsDisableSessionTickets bool
 	tlsCipherSuite           []uint16
 	proxyDialer              *netproxy.Dialer
@@ -526,7 +526,7 @@ func (xTransport *XTransport) Fetch(
 		dlog.Debugf("Has domain [%s] in hardcoded supported hosts", host)
 		hasAltSupport = true
 		xTransport.altSupport.Lock()
-		xTransport.altSupport.cache[url.Host] = uint16(port)
+		xTransport.altSupport.cache[url.Host] = xTransport.http3SupportedHosts[host]
 		dlog.Debugf("Caching altPort for [%v]", url.Host)
 		xTransport.altSupport.Unlock()
 	}


### PR DESCRIPTION
Hello team!

I have been struggling with some hosts with httpv3 for a long while and I created feature that it will force the use of http v3 protocol for those hosts in a configured host list under toml file, which won't check in the existence of http3 support via the `alt-svc` header that contains `h3: <target port>` and presumably supports http3 protocol

It works by the supplied list of hosts under the `dnscrypt-proxy.toml`
```
## Force the use of http3 on the supplied hosts
force_http3_hosts = ['<host>[:<port>]'] # e.g. force_http3_hosts = ['dns.cloudflare.com']
```

I hope this to be included in future version for people who will also need this as some DoH servers actually supports v3 but it can't be used such as NextDNS

Thanks!