### PR TITLE
Probe the HTTPv3 capability when http3=true

### DIFF
--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -624,6 +624,7 @@ func (xTransport *XTransport) Fetch(
 			if _, err := http3TestClient.Do(req); err != nil {
 				dlog.Noticef("Probe using HTTP/3 failed for [%s] with err: %v", url.Host, err)
 				success = false
+				http3TestClient.CloseIdleConnections()
 			}
 			xTransport.http3ProbeSuccessfulHosts.Lock()
 			xTransport.http3ProbeSuccessfulHosts.cache[host] = success

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -539,7 +539,7 @@ func (xTransport *XTransport) Fetch(
 		if hasAltSupport || (ok && probeSuccess) {
 			if int(altPort) == port {
 				client.Transport = xTransport.h3Transport
-				dlog.Debugf("Using HTTP/3 transport for [%s]", url.Host)
+				dlog.Noticef("Using HTTP/3 transport for [%s]", url.Host)
 			}
 		}
 	}
@@ -616,7 +616,7 @@ func (xTransport *XTransport) Fetch(
 		_, ok := xTransport.http3ProbeSuccessfulHosts.cache[host]
 		xTransport.http3ProbeSuccessfulHosts.RUnlock()
 		if !ok {
-			dlog.Infof("Probe using HTTP/3 for [%s]", url.Host)
+			dlog.Noticef("Probe using HTTP/3 for [%s]", url.Host)
 			http3TestClient := http.Client{
 				Transport: xTransport.h3Transport,
 				Timeout:   timeout,
@@ -624,7 +624,7 @@ func (xTransport *XTransport) Fetch(
 
 			success := true
 			if _, err := http3TestClient.Do(req); err != nil {
-				dlog.Infof("Probe using HTTP/3 failed for [%s]", url.Host)
+				dlog.Noticef("Probe using HTTP/3 failed for [%s]", url.Host)
 				success = false
 			}
 			xTransport.http3ProbeSuccessfulHosts.Lock()

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -622,7 +622,7 @@ func (xTransport *XTransport) Fetch(
 
 			success := true
 			if _, err := http3TestClient.Do(req); err != nil {
-				dlog.Noticef("Probe using HTTP/3 failed for [%s] with err: %v", url.Host, err)
+				dlog.Noticef("Probe using HTTP/3 failed for [%s]", url.Host)
 				success = false
 				http3TestClient.CloseIdleConnections()
 			}

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -624,7 +624,7 @@ func (xTransport *XTransport) Fetch(
 
 			success := true
 			if _, err := http3TestClient.Do(req); err != nil {
-				dlog.Noticef("Probe using HTTP/3 failed for [%s]", url.Host)
+				dlog.Noticef("Probe using HTTP/3 failed for [%s] with err: %v", url.Host, err)
 				success = false
 			}
 			xTransport.http3ProbeSuccessfulHosts.Lock()
@@ -632,7 +632,7 @@ func (xTransport *XTransport) Fetch(
 			xTransport.http3ProbeSuccessfulHosts.Unlock()
 		}
 
-		if !hasAltSupport {
+		if !xTransport.http3ProbeSuccessfulHosts.cache[host] && !hasAltSupport {
 			if alt, found := resp.Header["Alt-Svc"]; found {
 				dlog.Debugf("Alt-Svc [%s]: [%s]", url.Host, alt)
 				altPort := uint16(port & 0xffff)

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -534,13 +534,11 @@ func (xTransport *XTransport) Fetch(
 		altPort, hasAltSupport = xTransport.altSupport.cache[url.Host]
 		xTransport.altSupport.RUnlock()
 		xTransport.http3ProbeSuccessfulHosts.RLock()
-		probeSuccess, ok := xTransport.http3ProbeSuccessfulHosts.cache[host]
+		probeSuccess, hasProbed := xTransport.http3ProbeSuccessfulHosts.cache[host]
 		xTransport.http3ProbeSuccessfulHosts.RUnlock()
-		if hasAltSupport || (ok && probeSuccess) {
-			if int(altPort) == port {
-				client.Transport = xTransport.h3Transport
-				dlog.Noticef("Using HTTP/3 transport for [%s]", url.Host)
-			}
+		if (hasAltSupport && int(altPort) == port) || (hasProbed && probeSuccess) {
+			client.Transport = xTransport.h3Transport
+			dlog.Debugf("Using HTTP/3 transport for [%s]", url.Host)
 		}
 	}
 	header := map[string][]string{"User-Agent": {"dnscrypt-proxy"}}


### PR DESCRIPTION
This is a another pr aimed at probing httpv3 capability when `http3=true` is set
It would be a nice feature when the target resolver doesn't attach some httpv3 hints under header `alt-svc` with `h3: <port>` info
As @jedisct1 suggested in https://github.com/DNSCrypt/dnscrypt-proxy/pull/2846