### PR TITLE
prometheus: expose "build_info" gauge

### DIFF
--- a/dnscrypt-proxy/monitoring_ui.go
+++ b/dnscrypt-proxy/monitoring_ui.go
@@ -482,10 +482,6 @@ func (mc *MetricsCollector) generatePrometheusMetrics() string {
 	result.WriteString("# TYPE dnscrypt_proxy_queries_total counter\n")
 	result.WriteString(fmt.Sprintf("dnscrypt_proxy_queries_total %d\n", totalQueries))
 
-	result.WriteString("# HELP dnscrypt_proxy_queries_total Total number of DNS queries processed\n")
-	result.WriteString("# TYPE dnscrypt_proxy_queries_total counter\n")
-	result.WriteString(fmt.Sprintf("dnscrypt_proxy_queries_total %d\n", totalQueries))
-
 	result.WriteString("# HELP dnscrypt_proxy_queries_per_second Current queries per second rate\n")
 	result.WriteString("# TYPE dnscrypt_proxy_queries_per_second gauge\n")
 	result.WriteString(fmt.Sprintf("dnscrypt_proxy_queries_per_second %.2f\n", queriesPerSecond))

--- a/dnscrypt-proxy/monitoring_ui.go
+++ b/dnscrypt-proxy/monitoring_ui.go
@@ -7,6 +7,7 @@ import (
 	"html"
 	"net"
 	"net/http"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -473,6 +474,14 @@ func (mc *MetricsCollector) generatePrometheusMetrics() string {
 	var result strings.Builder
 
 	// Write help and type information for each metric
+	result.WriteString("# HELP dnscrypt_proxy_build_info A metric with a constant '1' value labeled by version, goversion from which dnscrypt_proxy was built, and the goos and goarch for the build.\n")
+	result.WriteString("# TYPE dnscrypt_proxy_build_info gauge\n")
+	result.WriteString(fmt.Sprintf("dnscrypt_proxy_build_info{goarch=\"%s\" goos=\"%s\" goversion=\"%s\" version=\"%s\"} 1\n", runtime.GOARCH, runtime.GOOS, runtime.Version(), AppVersion))
+
+	result.WriteString("# HELP dnscrypt_proxy_queries_total Total number of DNS queries processed\n")
+	result.WriteString("# TYPE dnscrypt_proxy_queries_total counter\n")
+	result.WriteString(fmt.Sprintf("dnscrypt_proxy_queries_total %d\n", totalQueries))
+
 	result.WriteString("# HELP dnscrypt_proxy_queries_total Total number of DNS queries processed\n")
 	result.WriteString("# TYPE dnscrypt_proxy_queries_total counter\n")
 	result.WriteString(fmt.Sprintf("dnscrypt_proxy_queries_total %d\n", totalQueries))


### PR DESCRIPTION
This Pull Request adds build time informations in a gauge metrics (à la `node_exporter`) when the `prometheus_enabled` flag is set to true

```
# HELP dnscrypt_proxy_build_info A metric with a constant '1' value labeled by version, goversion from which dnscrypt_proxy was built, and the goos and goarch for the build.
# TYPE dnscrypt_proxy_build_info gauge
dnscrypt_proxy_build_info{goarch="amd64" goos="linux" goversion="go1.24.3" version="2.1.12"} 1
```

Goal for me: be able to ensure latest (or a specific version) of `dnscrypt_proxy` is running on my machines.

I didn't want to touch the JSON for the "main" Monitoring UI/JSON as this has probably more implications, let me know if you want me to have a look.