### PR TITLE
sample config: update quad9 source URLs

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -790,7 +790,7 @@ prefix = ''
 ### Quad9
 
 # [sources.quad9-resolvers]
-#   urls = ['https://www.quad9.net/quad9-resolvers.md']
+#   urls = ['https://quad9.net/dnscrypt/quad9-resolvers.md', 'https://raw.githubusercontent.com/Quad9DNS/dnscrypt-settings/main/dnscrypt/quad9-resolvers.md']
 #   minisign_key = 'RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN'
 #   cache_file = 'quad9-resolvers.md'
 #   prefix = 'quad9-'


### PR DESCRIPTION
The existing quad9-resolvers.md URL no longer works. I found https://github.com/Quad9DNS/dnscrypt-settings with more up-to-date info.