### PR TITLE
Rename PatternMatcher's field names and improve pattern rule examples

### DIFF
--- a/dnscrypt-proxy/example-allowed-names.txt
+++ b/dnscrypt-proxy/example-allowed-names.txt
@@ -7,13 +7,14 @@
 ##
 ## Example of valid patterns:
 ##
-## ads.*         | matches anything with an "ads." prefix
-## *.example.com | matches example.com and all names within that zone such as www.example.com
-## example.com   | identical to the above
-## =example.com  | allows example.com but not *.example.com
-## *sex*         | matches any name containing that substring
-## ads[0-9]*     | matches "ads" followed by one or more digits
-## ads*.example* | *, ? and [] can be used anywhere, but prefixes/suffixes are faster
+## ads.*                    | matches anything with an "ads." prefix
+## *.example.com            | matches example.com and all names within that zone such as www.example.com
+## example.com              | identical to the above
+## =example.com             | allows example.com but not *.example.com
+## [a-z0-9\-_]*.example.com | allows *.example.com but not example.com
+## *sex*                    | matches any name containing that substring
+## ads[0-9]*                | matches "ads" followed by one or more digits
+## ads*.example*            | *, ? and [] can be used anywhere, but prefixes/suffixes are faster
 
 
 # That one may be blocked due to 'tracker' being in the name.

--- a/dnscrypt-proxy/example-blocked-names.txt
+++ b/dnscrypt-proxy/example-blocked-names.txt
@@ -7,13 +7,14 @@
 ##
 ## Example of valid patterns:
 ##
-## ads.*         | matches anything with an "ads." prefix
-## *.example.com | matches example.com and all names within that zone such as www.example.com
-## example.com   | identical to the above
-## =example.com  | block example.com but not *.example.com
-## *sex*         | matches any name containing that substring
-## ads[0-9]*     | matches "ads" followed by one or more digits
-## ads*.example* | *, ? and [] can be used anywhere, but prefixes/suffixes are faster
+## ads.*                    | matches anything with an "ads." prefix
+## *.example.com            | matches example.com and all names within that zone such as www.example.com
+## example.com              | identical to the above
+## =example.com             | blocks example.com but not *.example.com
+## [a-z0-9\-_]*.example.com | blocks *.example.com but not example.com
+## *sex*                    | matches any name containing that substring
+## ads[0-9]*                | matches "ads" followed by one or more digits
+## ads*.example*            | *, ? and [] can be used anywhere, but prefixes/suffixes are faster
 
 ad.*
 ads.*


### PR DESCRIPTION
* "block" initiated and extended to allowed and cloaking names
* `\-` stands for '-' in bracket expressions, requires `\`
* `_` is not allowed in host names, but allowed in DNS for special purpose