### PR TITLE
Skip getting a server candidate if unnecessary

### DIFF
--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -274,7 +274,7 @@ func NewPluginsState(
 func (pluginsState *PluginsState) ApplyQueryPlugins(
 	pluginsGlobals *PluginsGlobals,
 	packet []byte,
-	proxy *Proxy,
+	getServerInfo func() *ServerInfo,
 ) ([]byte, *ServerInfo, error) {
 	msg := dns.Msg{}
 	if err := msg.Unpack(packet); err != nil {
@@ -316,7 +316,7 @@ func (pluginsState *PluginsState) ApplyQueryPlugins(
 	needsEDNS0Padding := false
 	var serverInfo *ServerInfo
 	if pluginsState.action == PluginsActionContinue {
-		serverInfo = proxy.serversInfo.getOne()
+		serverInfo = getServerInfo()
 	}
 	if serverInfo != nil {
 		needsEDNS0Padding = (serverInfo.Proto == stamps.StampProtoTypeDoH || serverInfo.Proto == stamps.StampProtoTypeTLS)

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -714,7 +714,9 @@ func (proxy *Proxy) processIncomingQuery(
 	pluginsState := NewPluginsState(proxy, clientProto, clientAddr, serverProto, start)
 
 	// Apply query plugins and get server info
-	query, serverInfo, _ := pluginsState.ApplyQueryPlugins(&proxy.pluginsGlobals, query, proxy)
+	query, serverInfo, _ := pluginsState.ApplyQueryPlugins(&proxy.pluginsGlobals, query, func() *ServerInfo {
+		return proxy.serversInfo.getOne()
+	})
 
 	if !validateQuery(query) {
 		return response


### PR DESCRIPTION
Reduce locks.

Passing a `*Proxy` seems not elegant. But, it works, and avoids redoing unpack and repack the packets to add EDNS0 Padding outside `ApplyQueryPlugins`.
