### PR TITLE
Enable `systemctl reload` to send reload signal

### DIFF
--- a/dnscrypt-proxy/main.go
+++ b/dnscrypt-proxy/main.go
@@ -77,12 +77,15 @@ func main() {
 		flags: &flags,
 	}
 
+	svcOptions := make(service.KeyValue)
+	svcOptions["ReloadSignal"] = "HUP"
 	svcConfig := &service.Config{
 		Name:             "dnscrypt-proxy",
 		DisplayName:      "DNSCrypt client proxy",
 		Description:      "Encrypted/authenticated DNS proxy",
 		WorkingDirectory: pwd,
 		Arguments:        []string{"-config", *flags.ConfigFile},
+		Option:           svcOptions,
 	}
 	svc, err := service.New(app, svcConfig)
 	if err != nil {


### PR DESCRIPTION
Should resolve #2955

I'm not in a position to properly test my changes still but this looks simple enough with no obvious side-effects. I followed the upstream service module's [logging example](https://github.com/kardianos/service/blob/b7ded6fcb7497ba4f88edf9cc3445411175b8897/example/logging/main.go#L68) closely. A quick search of the upstream code suggests this option only has any effect in the context of SystemD on Linux and [will add an appropriate `ExecReload=` line](https://github.com/kardianos/service/blob/b7ded6fcb7497ba4f88edf9cc3445411175b8897/service_systemd_linux.go#L317) to the generated service file.