### PR TITLE
Improve target CNAME resolving for cloaking

### DIFF
--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -253,10 +253,11 @@ func (plugin *PluginCloak) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 		}
 	}
 	synth := EmptyResponseFromMessage(msg)
-	if !cloakedName.isIP && ((cloakedName.ipv4 == nil && cloakedName.ipv6 == nil) || expired) {
+	if !cloakedName.isIP && ((question.Qtype == dns.TypeA && cloakedName.ipv4 == nil) ||
+		(question.Qtype == dns.TypeAAAA && cloakedName.ipv6 == nil) || expired) {
 		target := cloakedName.target
 		plugin.RUnlock()
-		foundIPs, err := net.LookupIP(target)
+		foundIPs, _, err := pluginsState.xTransport.resolveEncrypted(target, question.Qtype)
 		if err != nil {
 			synth.Rcode = dns.RcodeServerFailure
 			pluginsState.synthResponse = synth

--- a/dnscrypt-proxy/plugin_cloak.go
+++ b/dnscrypt-proxy/plugin_cloak.go
@@ -290,8 +290,6 @@ func (plugin *PluginCloak) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 		// Reacquire read lock
 		plugin.RLock()
 	}
-	plugin.RUnlock()
-
 	synth.Answer = []dns.RR{}
 	if question.Qtype == dns.TypeA {
 		for _, ip := range cloakedName.ipv4 {
@@ -315,6 +313,8 @@ func (plugin *PluginCloak) Eval(pluginsState *PluginsState, msg *dns.Msg) error 
 			synth.Answer = append(synth.Answer, rr)
 		}
 	}
+	plugin.RUnlock()
+
 	rand.Shuffle(
 		len(synth.Answer),
 		func(i, j int) { synth.Answer[i], synth.Answer[j] = synth.Answer[j], synth.Answer[i] },

--- a/dnscrypt-proxy/plugins.go
+++ b/dnscrypt-proxy/plugins.go
@@ -75,6 +75,7 @@ type PluginsState struct {
 	clientAddr                       *net.Addr
 	synthResponse                    *dns.Msg
 	questionMsg                      *dns.Msg
+	xTransport                       *XTransport
 	sessionData                      map[string]interface{}
 	action                           PluginsAction
 	timeout                          time.Duration
@@ -267,6 +268,7 @@ func NewPluginsState(
 		requestStart:                     start,
 		maxUnencryptedUDPSafePayloadSize: MaxDNSUDPSafePacketSize,
 		sessionData:                      make(map[string]interface{}),
+		xTransport:                       proxy.xTransport,
 	}
 }
 

--- a/dnscrypt-proxy/systemd_linux.go
+++ b/dnscrypt-proxy/systemd_linux.go
@@ -9,6 +9,15 @@ import (
 	"github.com/jedisct1/dlog"
 )
 
+func hasStringElement(array []string, s string) bool {
+	for _, ele := range array {
+		if ele == s {
+			return true
+		}
+	}
+	return false
+}
+
 func (proxy *Proxy) addSystemDListeners() error {
 	files := activation.Files(true)
 
@@ -19,15 +28,22 @@ func (proxy *Proxy) addSystemDListeners() error {
 			)
 		}
 		dlog.Warn("Systemd sockets are untested and unsupported - use at your own risk")
+		proxy.listenAddresses = make([]string, 0)
 	}
 	for i, file := range files {
 		defer file.Close()
+		var listenAddress string
 		if listener, err := net.FileListener(file); err == nil {
 			proxy.registerTCPListener(listener.(*net.TCPListener))
-			dlog.Noticef("Wiring systemd TCP socket #%d, %s, %s", i, file.Name(), listener.Addr())
+			listenAddress = listener.Addr().String()
+			dlog.Noticef("Wiring systemd TCP socket #%d, %s, %s", i, file.Name(), listenAddress)
 		} else if pc, err := net.FilePacketConn(file); err == nil {
 			proxy.registerUDPListener(pc.(*net.UDPConn))
-			dlog.Noticef("Wiring systemd UDP socket #%d, %s, %s", i, file.Name(), pc.LocalAddr())
+			listenAddress = pc.LocalAddr().String()
+			dlog.Noticef("Wiring systemd UDP socket #%d, %s, %s", i, file.Name(), listenAddress)
+		}
+		if len(listenAddress) > 0 && !hasStringElement(proxy.listenAddresses, listenAddress) {
+			proxy.listenAddresses = append(proxy.listenAddresses, listenAddress)
 		}
 	}
 	return nil

--- a/dnscrypt-proxy/systemd_linux.go
+++ b/dnscrypt-proxy/systemd_linux.go
@@ -4,19 +4,11 @@ package main
 
 import (
 	"net"
+	"slices"
 
 	"github.com/coreos/go-systemd/activation"
 	"github.com/jedisct1/dlog"
 )
-
-func hasStringElement(array []string, s string) bool {
-	for _, ele := range array {
-		if ele == s {
-			return true
-		}
-	}
-	return false
-}
 
 func (proxy *Proxy) addSystemDListeners() error {
 	files := activation.Files(true)
@@ -42,7 +34,7 @@ func (proxy *Proxy) addSystemDListeners() error {
 			listenAddress = pc.LocalAddr().String()
 			dlog.Noticef("Wiring systemd UDP socket #%d, %s, %s", i, file.Name(), listenAddress)
 		}
-		if len(listenAddress) > 0 && !hasStringElement(proxy.listenAddresses, listenAddress) {
+		if len(listenAddress) > 0 && !slices.Contains(proxy.listenAddresses, listenAddress) {
 			proxy.listenAddresses = append(proxy.listenAddresses, listenAddress)
 		}
 	}

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -423,18 +423,8 @@ func (xTransport *XTransport) resolveUsingResolvers(
 	return ips, ttl, err
 }
 
-func (xTransport *XTransport) resolveEncrypted(host string, forceType uint16) (ips []net.IP, ttl time.Duration, err error) {
-	protos := []string{"udp", "tcp"}
-	if xTransport.mainProto == "tcp" {
-		protos = []string{"tcp", "udp"}
-	}
-	for _, proto := range protos {
-		ips, ttl, err = xTransport.resolveUsingResolvers(proto, host, xTransport.internalResolvers, forceType)
-		if err == nil {
-			break
-		}
-	}
-	return ips, ttl, err
+func (xTransport *XTransport) resolveEncrypted(host string, forceType uint16) ([]net.IP, time.Duration, error) {
+	return xTransport.resolveUsingResolvers(xTransport.mainProto, host, xTransport.internalResolvers, forceType)
 }
 
 func (xTransport *XTransport) resolve(host string, forceType uint16) (ips []net.IP, ttl time.Duration, err error) {

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -34,6 +34,7 @@ const (
 	DefaultBootstrapResolver = "9.9.9.9:53"
 	DefaultKeepAlive         = 5 * time.Second
 	DefaultTimeout           = 30 * time.Second
+	ResolverReadTimeout      = 5 * time.Second
 	SystemResolverIPTTL      = 12 * time.Hour
 	MinResolverIPTTL         = 4 * time.Hour
 	ResolverIPTTLMaxJitter   = 15 * time.Minute
@@ -361,7 +362,7 @@ func (xTransport *XTransport) resolveUsingResolver(
 	resolver string,
 	forceType uint16,
 ) (ips []net.IP, ttl time.Duration, err error) {
-	dnsClient := dns.Client{Net: proto}
+	dnsClient := dns.Client{Net: proto, ReadTimeout: ResolverReadTimeout}
 	queryType := make([]uint16, 0, 2)
 	switch forceType {
 	case dns.TypeA:

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -344,12 +344,13 @@ func (xTransport *XTransport) resolveUsingSystem(host string, forceType uint16) 
 	}
 	ips := make([]net.IP, 0)
 	for _, ip := range ipa {
+		ipv4 := ip.To4()
 		if queryIPv4 {
-			if ipv4 := ip.To4(); ipv4 != nil {
-				ips = append(ips, ip)
+			if ipv4 != nil {
+				ips = append(ips, ipv4)
 			}
 		} else if queryIPv6 {
-			if ipv6 := ip.To16(); ipv6 != nil {
+			if ipv4 == nil {
 				ips = append(ips, ip)
 			}
 		}


### PR DESCRIPTION
Avoid bypass and increase privacy.

Issues with CNAME cloaking rules:
* Rule bypass if upstream server fails
* Privacy leak if `net.LookupIP`/`net.LookupHost` flows to plain DNS
* Out of service if clients query AAAA records but IPv6 connection is not available
