### PR TITLE
Reduce flood debug messages that have been clearified at startup

### DIFF
--- a/dnscrypt-proxy/query_processing.go
+++ b/dnscrypt-proxy/query_processing.go
@@ -351,12 +351,6 @@ func updateMonitoringMetrics(
 		dlog.Debugf("Calling UpdateMetrics for query: %s", pluginsState.qName)
 		proxy.monitoringInstance.UpdateMetrics(*pluginsState, pluginsState.questionMsg)
 	} else {
-		if !proxy.monitoringUI.Enabled {
-			dlog.Debugf("Monitoring UI not enabled")
-		}
-		if proxy.monitoringInstance == nil {
-			dlog.Debugf("Monitoring instance is nil")
-		}
 		if pluginsState.questionMsg == nil {
 			dlog.Debugf("Question message is nil")
 		}


### PR DESCRIPTION
https://github.com/DNSCrypt/dnscrypt-proxy/blob/e32fd479fb57ea3dfe4469031bd826f29decf747/dnscrypt-proxy/proxy.go#L265-L279

When monitoring UI is not enabled, they are flooding other messages.
