### PR TITLE
Do not truncate buffer size of client UDP datagrams

### DIFF
--- a/dnscrypt-proxy/coldstart.go
+++ b/dnscrypt-proxy/coldstart.go
@@ -78,7 +78,7 @@ func HandleCaptivePortalQuery(msg *dns.Msg, question *dns.Question, ips *Captive
 }
 
 func handleColdStartClient(clientPc *net.UDPConn, cancelChannel chan struct{}, ipsMap *CaptivePortalMap) bool {
-	buffer := make([]byte, MaxDNSPacketSize-1)
+	buffer := make([]byte, MaxDNSPacketSize)
 	clientPc.SetDeadline(time.Now().Add(time.Duration(1) * time.Second))
 	length, clientAddr, err := clientPc.ReadFrom(buffer)
 	exit := false


### PR DESCRIPTION
Previously, handleColdStartClient would error out due to a truncated legitimate maximum-size EDNS0 query.