### PR TITLE
Do not double-append system resolver list when using IPV6.

### DIFF
--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -339,11 +339,13 @@ func (xTransport *XTransport) resolveUsingSystem(host string) (ip net.IP, ttl ti
 			if xTransport.useIPv4 {
 				if ipv4 := foundIP.To4(); ipv4 != nil {
 					ips = append(ips, foundIP)
+					continue
 				}
 			}
 			if xTransport.useIPv6 {
 				if ipv6 := foundIP.To16(); ipv6 != nil {
 					ips = append(ips, foundIP)
+					continue
 				}
 			}
 		}


### PR DESCRIPTION
To16() returns a non-nil 16-byte form for both IPv4 and IPv6 addresses,so IPv4 addresses also satisfy the condition `ipv6 := foundIP.To16(); ipv6 != nil`. As a result, if useIPv6 is true and useIPv4 is false IPv4 addresses will still be appended to ips and can be returned, and if both flags are true IPv4 addresses can be appended twice.  This logic violates the configured IPv4/IPv6 preferences and biases the selection toward IPv4.