### PR TITLE
Treat NXDOMAIN as a valid answer, and SERVFAIL as invalid, per RFC 2308

### DIFF
--- a/dnscrypt-proxy/plugin_forward.go
+++ b/dnscrypt-proxy/plugin_forward.go
@@ -331,7 +331,7 @@ func (plugin *PluginForward) Eval(pluginsState *PluginsState, msg *dns.Msg) erro
 		pluginsState.returnCode = PluginsReturnCodeForward
 		if len(sequence) > 0 {
 			switch respMsg.Rcode {
-			case dns.RcodeNameError, dns.RcodeRefused, dns.RcodeNotAuth:
+			case dns.RcodeServerFailure, dns.RcodeRefused, dns.RcodeNotAuth:
 				continue
 			}
 		}


### PR DESCRIPTION
RFC 2308 states that NXDOMAIN answers should be handled as a authorative negative response, and therefore are cacheable. As such, there is no need to retry other servers when this response is seen.  SERVFAIL should be treated as an invalid answer, which is retried.