### PR TITLE
Minor change to LBStrategyPH.getActiveCount()

### DIFF
--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -98,11 +98,11 @@ func (s LBStrategyPN) getActiveCount(serversCount int) int {
 type LBStrategyPH struct{}
 
 func (LBStrategyPH) getCandidate(serversCount int) int {
-	return rand.Intn(Max(Min(serversCount, 2), serversCount/2))
+	return rand.Intn((serversCount + 1) / 2)
 }
 
 func (LBStrategyPH) getActiveCount(serversCount int) int {
-	return Max(Min(serversCount, 2), serversCount/2)
+	return (serversCount + 1) / 2
 }
 
 type LBStrategyFirst struct{}


### PR DESCRIPTION
Special case: 2 servers, 1 is dead, and estimatorUpdate is skipped.
```
Count   Before  After
1       1       1
2       2       1
3       2       2
4       2       2
5       2       3
6       3       3
7       3       4
```
https://github.com/DNSCrypt/dnscrypt-proxy/blob/4457dd52f2f12379b1da5b0f6442c78d21de43aa/dnscrypt-proxy/serversInfo.go#L298-L300
