### PR TITLE
Show number of goroutines if reaches max clients

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -442,6 +442,7 @@ func (proxy *Proxy) udpListener(clientPc *net.UDPConn) {
 		packet := buffer[:length]
 		if !proxy.clientsCountInc() {
 			dlog.Warnf("Too many incoming connections (max=%d)", proxy.maxClients)
+			dlog.Debugf("Number of goroutines: %d", runtime.NumGoroutine())
 			proxy.processIncomingQuery(
 				"udp",
 				proxy.mainProto,
@@ -469,6 +470,7 @@ func (proxy *Proxy) tcpListener(acceptPc *net.TCPListener) {
 		}
 		if !proxy.clientsCountInc() {
 			dlog.Warnf("Too many incoming connections (max=%d)", proxy.maxClients)
+			dlog.Debugf("Number of goroutines: %d", runtime.NumGoroutine())
 			clientPc.Close()
 			continue
 		}


### PR DESCRIPTION
Need it to reveal info about the workload.

For example:
```
[2025-11-10 08:07:40] [WARNING] Too many incoming connections (max=500), number of goroutines: 806
[2025-11-10 08:07:40] [WARNING] Too many incoming connections (max=500), number of goroutines: 807
[2025-11-10 08:07:40] [WARNING] Too many incoming connections (max=500), number of goroutines: 807
```