### PR TITLE
Create completely new results for server refreshing

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -664,7 +664,7 @@ func (config *Config) loadSources(proxy *Proxy) error {
 			if stamp.Proto == stamps.StampProtoTypeDNSCryptRelay || stamp.Proto == stamps.StampProtoTypeODoHRelay {
 				dlog.Debugf("Adding [%s] to the set of available static relays", name)
 				registeredServer := RegisteredServer{name: name, stamp: stamp, description: "static relay"}
-				proxy.registeredRelays = append(proxy.registeredRelays, registeredServer)
+				proxy.staticRelays = append(proxy.staticRelays, registeredServer)
 			}
 		}
 	}
@@ -685,7 +685,7 @@ func (config *Config) loadSources(proxy *Proxy) error {
 		if err != nil {
 			return fmt.Errorf("Stamp error for the static [%s] definition: [%v]", serverName, err)
 		}
-		proxy.registeredServers = append(proxy.registeredServers, RegisteredServer{name: serverName, stamp: stamp})
+		proxy.staticServers = append(proxy.staticServers, RegisteredServer{name: serverName, stamp: stamp})
 	}
 	if err := proxy.updateRegisteredServers(); err != nil {
 		return err

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -175,6 +175,14 @@ func NewServersInfo() ServersInfo {
 	}
 }
 
+func (serversInfo *ServersInfo) registerServers(registeredServers []RegisteredServer) {
+	rs := make([]RegisteredServer, len(registeredServers))
+	copy(rs, registeredServers)
+	serversInfo.Lock()
+	serversInfo.registeredServers = rs
+	serversInfo.Unlock()
+}
+
 func (serversInfo *ServersInfo) registerServer(name string, stamp stamps.ServerStamp) {
 	newRegisteredServer := RegisteredServer{name: name, stamp: stamp}
 	serversInfo.Lock()
@@ -186,6 +194,14 @@ func (serversInfo *ServersInfo) registerServer(name string, stamp stamps.ServerS
 		}
 	}
 	serversInfo.registeredServers = append(serversInfo.registeredServers, newRegisteredServer)
+}
+
+func (serversInfo *ServersInfo) registerRelays(registeredRelays []RegisteredServer) {
+	rr := make([]RegisteredServer, len(registeredRelays))
+	copy(rr, registeredRelays)
+	serversInfo.Lock()
+	serversInfo.registeredRelays = rr
+	serversInfo.Unlock()
 }
 
 func (serversInfo *ServersInfo) registerRelay(name string, stamp stamps.ServerStamp) {


### PR DESCRIPTION
Exclude servers/relays that have been removed from the sources, had their privacy level lowered, or IPv6 has became unavailable.

Don't need to shuffle `proxy.registeredServers`, update/10min; shuffle `ServersInfo.registeredServers` is enough.

PS: Distinguishing updating existing and adding new items increases complexity.