### PR TITLE
CI: need bash rather than dash to get $LINENO on Ubuntu

### DIFF
--- a/.ci/ci-test.sh
+++ b/.ci/ci-test.sh
@@ -12,6 +12,7 @@ t() {
     false
 }
 
+# Need bash rather than dash to get $LINENO on Ubuntu
 fail() (
     echo "*** Test #${TEST_COUNT} FAILED, line: $1 ***" >&2
 )

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           go version
           cd .ci
+          # Need bash rather than dash to get $LINENO on Ubuntu
+          sudo ln -sf /bin/bash /bin/sh
           ./ci-test.sh
           cd -
 


### PR DESCRIPTION
`ls -l /bin/sh` yields:
/bin/sh -> /bin/dash

I never would have thought this.