### PR TITLE
Add bounds check to HasTCFlag

### DIFF
--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -112,6 +112,9 @@ func RefusedResponseFromMessage(srcMsg *dns.Msg, refusedCode bool, ipv4 net.IP, 
 }
 
 func HasTCFlag(packet []byte) bool {
+	if len(packet) < 3 {
+		return false
+	}
 	return packet[2]&2 == 2
 }
 


### PR DESCRIPTION
Fixes #3208

Prevent panic on packets shorter than 3 bytes.