### PR TITLE
Fix double strings.ToLower in ipcrypt.go

### DIFF
--- a/dnscrypt-proxy/ipcrypt.go
+++ b/dnscrypt-proxy/ipcrypt.go
@@ -45,7 +45,7 @@ func NewIPCryptConfig(keyHex string, algorithm string) (*IPCryptConfig, error) {
 	}
 
 	// Validate key length and prepare config based on algorithm
-	switch strings.ToLower(algorithm) {
+	switch config.Algorithm {
 	case "ipcrypt-deterministic":
 		// Deterministic IPCrypt uses 16-byte keys
 		if len(key) != 16 {


### PR DESCRIPTION
Fixes #3215

Use already-normalized config.Algorithm value in the switch statement instead of calling strings.ToLower a second time.