### PR TITLE
Fix log level config silently overridden by env var check

### DIFF
--- a/dnscrypt-proxy/config_loader.go
+++ b/dnscrypt-proxy/config_loader.go
@@ -29,9 +29,6 @@ func configureLogging(proxy *Proxy, flags *ConfigFlags, config *Config) {
 	if config.LogLevel >= 0 && config.LogLevel < int(dlog.SeverityLast) {
 		dlog.SetLogLevel(dlog.Severity(config.LogLevel))
 	}
-	if dlog.LogLevel() <= dlog.SeverityDebug && os.Getenv("DEBUG") == "" {
-		dlog.SetLogLevel(dlog.SeverityInfo)
-	}
 	dlog.TruncateLogFile(config.LogFileLatest)
 
 	isCommandMode := false


### PR DESCRIPTION
Fixes #3211

Remove the DEBUG env var override that silently promoted user-configured debug logging to info.