### PR TITLE
Fix data race on internalResolverReady field

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -292,7 +292,7 @@ func (proxy *Proxy) StartProxy() {
 			dlog.Fatal(err)
 		}
 	}
-	proxy.xTransport.internalResolverReady = false
+	proxy.xTransport.internalResolverReady.Store(false)
 	proxy.xTransport.internalResolvers = proxy.listenAddresses
 	liveServers, err := proxy.serversInfo.refresh(proxy)
 	if liveServers > 0 {

--- a/dnscrypt-proxy/serversInfo.go
+++ b/dnscrypt-proxy/serversInfo.go
@@ -261,7 +261,7 @@ func (serversInfo *ServersInfo) refresh(proxy *Proxy) (int, error) {
 		go func(registeredServer *RegisteredServer) {
 			err := serversInfo.refreshServer(proxy, registeredServer.name, registeredServer.stamp)
 			if err == nil {
-				proxy.xTransport.internalResolverReady = true
+				proxy.xTransport.internalResolverReady.Store(true)
 			}
 			errorChannel <- err
 			<-countChannel

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"codeberg.org/miekg/dns"
@@ -78,7 +79,7 @@ type XTransport struct {
 	bootstrapResolvers       []string
 	mainProto                string
 	ignoreSystemDNS          bool
-	internalResolverReady    bool
+	internalResolverReady    atomic.Bool
 	useIPv4                  bool
 	useIPv6                  bool
 	http3                    bool
@@ -559,7 +560,7 @@ func (xTransport *XTransport) resolve(host string, returnIPv4, returnIPv6 bool) 
 		protos = []string{"tcp", "udp"}
 	}
 	if xTransport.ignoreSystemDNS {
-		if xTransport.internalResolverReady {
+		if xTransport.internalResolverReady.Load() {
 			for _, proto := range protos {
 				ips, ttl, err = xTransport.resolveUsingServers(proto, host, xTransport.internalResolvers, returnIPv4, returnIPv6)
 				if err == nil {


### PR DESCRIPTION
Fixes #3205

Use atomic.Bool instead of plain bool to synchronize access across goroutines in server refresh loop.