### PR TITLE
Fix discarded error from serversInfo.refresh() in proxy.go

### DIFF
--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -328,7 +328,10 @@ func (proxy *Proxy) StartProxy() {
 					delay = proxy.certRefreshDelayAfterFailure
 				}
 				clocksmith.Sleep(delay)
-				liveServers, _ = proxy.serversInfo.refresh(proxy)
+				liveServers, err = proxy.serversInfo.refresh(proxy)
+				if err != nil {
+					dlog.Warnf("Server refresh error: %v", err)
+				}
 				if liveServers > 0 {
 					proxy.certIgnoreTimestamp = false
 				}


### PR DESCRIPTION
Fixes #3214

Log the error returned by serversInfo.refresh() to aid debugging when server certificate refresh fails.