### PR TITLE
chore: improve dnscrypt-proxy maintenance path

### DIFF
--- a/dnscrypt-proxy/common.go
+++ b/dnscrypt-proxy/common.go
@@ -181,14 +181,20 @@ func isDigit(b byte) bool { return b >= '0' && b <= '9' }
 
 // ExtractClientIPStr extracts client IP string from pluginsState based on protocol
 func ExtractClientIPStr(pluginsState *PluginsState) (string, bool) {
-	if pluginsState.clientAddr == nil {
+	if pluginsState == nil || pluginsState.clientAddr == nil {
 		return "", false
 	}
 	switch pluginsState.clientProto {
 	case "udp":
-		return (*pluginsState.clientAddr).(*net.UDPAddr).IP.String(), true
+		if udpAddr, ok := (*pluginsState.clientAddr).(*net.UDPAddr); ok {
+			return udpAddr.IP.String(), true
+		}
+		return "", false
 	case "tcp", "local_doh":
-		return (*pluginsState.clientAddr).(*net.TCPAddr).IP.String(), true
+		if tcpAddr, ok := (*pluginsState.clientAddr).(*net.TCPAddr); ok {
+			return tcpAddr.IP.String(), true
+		}
+		return "", false
 	default:
 		return "", false
 	}

--- a/dnscrypt-proxy/common_test.go
+++ b/dnscrypt-proxy/common_test.go
@@ -56,6 +56,97 @@ func TestExtractClientIPStr(t *testing.T) {
 			wantOK: true,
 		},
 		{
+			name:         "nil pluginsState should return empty",
+			pluginsState: nil,
+			wantIP:       "",
+			wantOK:       false,
+		},
+		{
+			name: "valid local_doh address",
+			pluginsState: &PluginsState{
+				clientProto: "local_doh",
+				clientAddr: func() *net.Addr {
+					addr := net.Addr(
+						&net.TCPAddr{
+							IP:   net.ParseIP("127.0.0.1"),
+							Port: 443,
+						},
+					)
+					return &addr
+				}(),
+			},
+			wantIP: "127.0.0.1",
+			wantOK: true,
+		},
+		{
+			name: "valid IPv6 UDP address",
+			pluginsState: &PluginsState{
+				clientProto: "udp",
+				clientAddr: func() *net.Addr {
+					addr := net.Addr(
+						&net.UDPAddr{
+							IP:   net.ParseIP("::1"),
+							Port: 53,
+						},
+					)
+					return &addr
+				}(),
+			},
+			wantIP: "::1",
+			wantOK: true,
+		},
+		{
+			name: "valid IPv6 TCP address",
+			pluginsState: &PluginsState{
+				clientProto: "tcp",
+				clientAddr: func() *net.Addr {
+					addr := net.Addr(
+						&net.TCPAddr{
+							IP:   net.ParseIP("2001:db8::1"),
+							Port: 53,
+						},
+					)
+					return &addr
+				}(),
+			},
+			wantIP: "2001:db8::1",
+			wantOK: true,
+		},
+		{
+			name: "UDP protocol with TCPAddr type mismatch",
+			pluginsState: &PluginsState{
+				clientProto: "udp",
+				clientAddr: func() *net.Addr {
+					addr := net.Addr(
+						&net.TCPAddr{
+							IP:   net.ParseIP("10.0.0.1"),
+							Port: 53,
+						},
+					)
+					return &addr
+				}(),
+			},
+			wantIP: "",
+			wantOK: false,
+		},
+		{
+			name: "TCP protocol with UDPAddr type mismatch",
+			pluginsState: &PluginsState{
+				clientProto: "tcp",
+				clientAddr: func() *net.Addr {
+					addr := net.Addr(
+						&net.UDPAddr{
+							IP:   net.ParseIP("10.0.0.1"),
+							Port: 53,
+						},
+					)
+					return &addr
+				}(),
+			},
+			wantIP: "",
+			wantOK: false,
+		},
+		{
 			name: "unknown protocol",
 			pluginsState: &PluginsState{
 				clientProto: "unknown",


### PR DESCRIPTION
Summary:
- Add or tighten focused edge-case tests or type assertions in dnscrypt-proxy/common_test.go, dnscrypt-proxy/fuzzing_test.go related to CI, Docker, Kubernetes, build tooling, release automation; avoid docs-only changes and broad refactors.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.