### PR TITLE
Improve comment about Tor circuit sharing

### DIFF
--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -128,7 +128,7 @@ http3_probe = false
 ## Uncomment the following line to route all TCP connections to a local Tor node
 ## Tor doesn't support UDP, so set `force_tcp` to `true` as well. When passing
 ## a random username and password to Tor's socks5 connection, dnscrypt-proxy gets
-## an isolated circuit so it will not share an exit node with other applications.
+## an isolated circuit that will not share the same path with other applications.
 ## Note: the random username and password used by dnscrypt-proxy should not
 ## actually be defined in Tor's configuration.
 


### PR DESCRIPTION
There is no guarantee that the Tor exit node is different for isolated streams. An attempt is made to make the path through the Tor network different for isolated streams, which means that at least one node will be different, and that is not necessarily the exit node.