### PR TITLE
Match name suffix rules on label boundaries

### DIFF
--- a/dnscrypt-proxy/pattern_matcher.go
+++ b/dnscrypt-proxy/pattern_matcher.go
@@ -127,21 +127,20 @@ func (patternMatcher *PatternMatcher) Eval(qName string) (reject bool, reason st
 		return true, qName, xval
 	}
 
+	// Suffix rules are stored reversed, so the longest matching byte prefix is
+	// not necessarily aligned on a label boundary. When it isn't, retry against
+	// the shorter rules instead of giving up. Rules are never empty, so the
+	// candidate always shrinks.
 	revQname := StringReverse(qName)
-	if match, xval, found := patternMatcher.suffixes.LongestPrefix([]byte(revQname)); found {
+	for candidate := revQname; len(candidate) > 0; {
+		match, xval, found := patternMatcher.suffixes.LongestPrefix([]byte(candidate))
+		if !found {
+			break
+		}
 		if len(match) == len(revQname) || revQname[len(match)] == '.' {
 			return true, "*." + StringReverse(string(match)), xval
 		}
-		if len(match) < len(revQname) && len(revQname) > 0 {
-			if i := strings.LastIndex(revQname, "."); i > 0 {
-				pName := revQname[:i]
-				if match, xval2, found := patternMatcher.suffixes.LongestPrefix([]byte(pName)); found {
-					if len(match) == len(pName) || pName[len(match)] == '.' {
-						return true, "*." + StringReverse(string(match)), xval2
-					}
-				}
-			}
-		}
+		candidate = candidate[:len(match)-1]
 	}
 
 	if match, xval, found := patternMatcher.prefixes.LongestPrefix([]byte(qName)); found {

--- a/dnscrypt-proxy/pattern_matcher_test.go
+++ b/dnscrypt-proxy/pattern_matcher_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestPatternMatcherSuffixLabelBoundary(t *testing.T) {
+	tests := []struct {
+		name       string
+		rules      []string
+		qName      string
+		wantReject bool
+		wantReason string
+	}{
+		{
+			name:       "zone rule matches a name in the zone",
+			rules:      []string{"example.com"},
+			qName:      "www.xads.example.com",
+			wantReject: true,
+			wantReason: "*.example.com",
+		},
+		{
+			name:       "a more specific rule does not hide the zone rule",
+			rules:      []string{"example.com", "ads.example.com"},
+			qName:      "www.xads.example.com",
+			wantReject: true,
+			wantReason: "*.example.com",
+		},
+		{
+			name:       "the most specific matching rule wins",
+			rules:      []string{"example.com", "ads.example.com"},
+			qName:      "www.ads.example.com",
+			wantReject: true,
+			wantReason: "*.ads.example.com",
+		},
+		{
+			name:       "several unaligned rules still fall back to the zone rule",
+			rules:      []string{"example.com", "ads.example.com", "s.example.com"},
+			qName:      "a.b.xads.example.com",
+			wantReject: true,
+			wantReason: "*.example.com",
+		},
+		{
+			name:       "a rule is not matched in the middle of a label",
+			rules:      []string{"ads.example.com"},
+			qName:      "www.xads.example.com",
+			wantReject: false,
+			wantReason: "",
+		},
+		{
+			name:       "a rule matches the zone apex itself",
+			rules:      []string{"example.com", "ads.example.com"},
+			qName:      "example.com",
+			wantReject: true,
+			wantReason: "*.example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patternMatcher := NewPatternMatcher()
+			for lineNo, rule := range tt.rules {
+				if err := patternMatcher.Add(rule, rule, lineNo+1); err != nil {
+					t.Fatalf("Add(%q) returned error: %v", rule, err)
+				}
+			}
+			gotReject, gotReason, _ := patternMatcher.Eval(tt.qName)
+			if gotReject != tt.wantReject {
+				t.Errorf("Eval(%q) reject = %v, want %v", tt.qName, gotReject, tt.wantReject)
+			}
+			if gotReason != tt.wantReason {
+				t.Errorf("Eval(%q) reason = %v, want %v", tt.qName, gotReason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// evalSuffixRules is a deliberately naive implementation of the suffix rule
+// semantics documented in example-blocked-names.txt: a rule matches the name it
+// names, and every name below it. The differential test below compares the
+// matcher against it.
+func evalSuffixRules(rules []string, qName string) (bool, string) {
+	longest := ""
+	for _, rule := range rules {
+		if qName != rule && !strings.HasSuffix(qName, "."+rule) {
+			continue
+		}
+		if len(rule) > len(longest) {
+			longest = rule
+		}
+	}
+	if longest == "" {
+		return false, ""
+	}
+	return true, "*." + longest
+}
+
+func TestPatternMatcherSuffixDifferential(t *testing.T) {
+	const cases = 20000
+
+	// Labels chosen so that one rule is frequently a byte suffix of a query
+	// without being a label of it ("ads" inside "xads", "ex" inside "xex").
+	labels := []string{"a", "xa", "ad", "ads", "xads", "ex", "xex", "example"}
+	tlds := []string{"com", "net"}
+
+	random := rand.New(rand.NewSource(20260731))
+	pick := func(list []string) string { return list[random.Intn(len(list))] }
+	prefix := func(count int) []string {
+		parts := make([]string, 0, count)
+		for range count {
+			parts = append(parts, pick(labels))
+		}
+		return parts
+	}
+
+	mismatches := 0
+	for range cases {
+		rules := make([]string, 0, 4)
+		for range 1 + random.Intn(4) {
+			rules = append(rules, strings.Join(append(prefix(1+random.Intn(2)), pick(tlds)), "."))
+		}
+		// Half of the queries are built below an existing rule, so that a
+		// missed match is a rule that silently stopped working.
+		base := strings.Join(append(prefix(1), pick(tlds)), ".")
+		if random.Intn(2) == 0 {
+			base = pick(rules)
+		}
+		qName := strings.Join(append(prefix(random.Intn(3)), base), ".")
+
+		patternMatcher := NewPatternMatcher()
+		for lineNo, rule := range rules {
+			if err := patternMatcher.Add(rule, rule, lineNo+1); err != nil {
+				t.Fatalf("Add(%q) returned error: %v", rule, err)
+			}
+		}
+		gotReject, gotReason, _ := patternMatcher.Eval(qName)
+		wantReject, wantReason := evalSuffixRules(rules, qName)
+		if gotReject == wantReject && gotReason == wantReason {
+			continue
+		}
+		mismatches++
+		if mismatches <= 5 {
+			t.Errorf(
+				"rules %v, Eval(%q) = (%v, %v), want (%v, %v)",
+				rules, qName, gotReject, gotReason, wantReject, wantReason,
+			)
+		}
+	}
+	if mismatches != 0 {
+		t.Errorf("%d of %d generated cases disagree with the reference implementation", mismatches, cases)
+	} else {
+		t.Logf("%d generated cases, no disagreement with the reference implementation", cases)
+	}
+}


### PR DESCRIPTION
With both `example.com` and `ads.example.com` in a blocklist, `www.xads.example.com` is not blocked. Remove the `ads.example.com` line and it is. Adding a more specific rule turns off a broader one.

`example-blocked-names.txt` says what the broad rule is supposed to cover:

```
## *.example.com            | matches example.com and all names within that zone such as www.example.com
## example.com              | identical to the above
```

Suffix rules go into a critbit trie keyed by the reversed name, and `Eval()` looks them up with `LongestPrefix()`, which returns the longest matching *byte* prefix. Reversed, `www.xads.example.com` is `moc.elpmaxe.sdax.www`. The longest key matching that is `moc.elpmaxe.sda`, i.e. `ads.example.com`, and it lands in the middle of the `xads` label, so the boundary check rejects it. That part is right. What goes wrong is the retry: it drops a label off the query instead of moving on to the shorter rules, so `moc.elpmaxe` never gets looked at. A single retry also only ever reaches one level up, so `xads.example.com` still matches but `www.xads.example.com` and anything deeper does not.

The same matcher is behind `blocked_names`, `allowed_names` and `cloaking_rules`.

The change keeps retrying against shorter rules until one lines up on a label boundary.

Before, on 610904bba816e2547b7a95cd5f8de776c1939ad1 with the new tests applied:

```
=== RUN   TestPatternMatcherSuffixLabelBoundary/a_more_specific_rule_does_not_hide_the_zone_rule
    pattern_matcher_test.go:71: Eval("www.xads.example.com") reject = false, want true
    pattern_matcher_test.go:74: Eval("www.xads.example.com") reason = , want *.example.com
=== RUN   TestPatternMatcherSuffixLabelBoundary/several_unaligned_rules_still_fall_back_to_the_zone_rule
    pattern_matcher_test.go:71: Eval("a.b.xads.example.com") reject = false, want true
    pattern_matcher_test.go:74: Eval("a.b.xads.example.com") reason = , want *.example.com
--- FAIL: TestPatternMatcherSuffixLabelBoundary (0.00s)
=== RUN   TestPatternMatcherSuffixDifferential
    pattern_matcher_test.go:145: rules [xads.net ads.xads.com xads.com xads.com], Eval("ad.xads.xads.com") = (false, ), want (true, *.xads.com)
    pattern_matcher_test.go:145: rules [ex.net ad.net ads.ex.net], Eval("xex.xads.ex.net") = (false, ), want (true, *.ex.net)
    pattern_matcher_test.go:145: rules [ex.xads.net xads.net], Eval("xa.xex.xads.net") = (false, ), want (true, *.xads.net)
    pattern_matcher_test.go:145: rules [ads.xex.net example.net xads.com ads.xads.com], Eval("xa.xads.xads.com") = (false, ), want (true, *.xads.com)
    pattern_matcher_test.go:145: rules [xads.net ads.ex.net ex.net], Eval("xads.xads.ex.net") = (false, ), want (true, *.ex.net)
    pattern_matcher_test.go:152: 9 of 20000 generated cases disagree with the reference implementation
--- FAIL: TestPatternMatcherSuffixDifferential (0.04s)
FAIL
```

After:

```
--- PASS: TestPatternMatcherSuffixLabelBoundary (0.00s)
    --- PASS: TestPatternMatcherSuffixLabelBoundary/zone_rule_matches_a_name_in_the_zone (0.00s)
    --- PASS: TestPatternMatcherSuffixLabelBoundary/a_more_specific_rule_does_not_hide_the_zone_rule (0.00s)
    --- PASS: TestPatternMatcherSuffixLabelBoundary/the_most_specific_matching_rule_wins (0.00s)
    --- PASS: TestPatternMatcherSuffixLabelBoundary/several_unaligned_rules_still_fall_back_to_the_zone_rule (0.00s)
    --- PASS: TestPatternMatcherSuffixLabelBoundary/a_rule_is_not_matched_in_the_middle_of_a_label (0.00s)
    --- PASS: TestPatternMatcherSuffixLabelBoundary/a_rule_matches_the_zone_apex_itself (0.00s)
=== RUN   TestPatternMatcherSuffixDifferential
    pattern_matcher_test.go:154: 20000 generated cases, no disagreement with the reference implementation
--- PASS: TestPatternMatcherSuffixDifferential (0.05s)
PASS
```

The differential test builds random rule sets from labels that overlap on byte boundaries (`ads` inside `xads`) and compares `Eval()` against a naive implementation of the documented semantics.

Full suite, `gofmt` and `go vet`:

```
$ make test
cd dnscrypt-proxy && go test  -tags "" ./...
ok  	github.com/dnscrypt/dnscrypt-proxy/dnscrypt-proxy	2.791s

$ make vet
cd dnscrypt-proxy && go vet ./...

$ gofmt -l dnscrypt-proxy/
```

The loop runs more than once only when a rule matches byte-wise without landing on a label boundary. I benchmarked `Eval()` against a matcher holding 100k random rules with queries that match nothing: 29.1 µs/op before, 29.4 µs/op after.