### PR TITLE
Add outgoing_interface to bind the source address of outgoing queries

### DIFF
--- a/dnscrypt-proxy/config.go
+++ b/dnscrypt-proxy/config.go
@@ -97,6 +97,7 @@ type Config struct {
 	TLSKeyLogFile            string                      `toml:"tls_key_log_file"`
 	NetprobeAddress          string                      `toml:"netprobe_address"`
 	NetprobeTimeout          int                         `toml:"netprobe_timeout"`
+	OutgoingInterface        string                      `toml:"outgoing_interface"`
 	OfflineMode              bool                        `toml:"offline_mode"`
 	HTTPProxyURL             string                      `toml:"http_proxy"`
 	RefusedCodeInResponses   bool                        `toml:"refused_code_in_responses"`

--- a/dnscrypt-proxy/config_loader.go
+++ b/dnscrypt-proxy/config_loader.go
@@ -96,6 +96,18 @@ func configureXTransport(proxy *Proxy, config *Config) error {
 	proxy.xTransport.useIPv6 = config.SourceIPv6
 	proxy.xTransport.keepAlive = time.Duration(config.KeepAlive) * time.Second
 
+	outgoing, err := newOutgoingSource(config.OutgoingInterface)
+	if err != nil {
+		return err
+	}
+	if outgoing != nil && (len(config.Proxy) > 0 || len(config.HTTPProxyURL) > 0) {
+		dlog.Warn("outgoing_interface has no effect on connections made through a proxy")
+	}
+	proxy.xTransport.outgoing = outgoing
+	if outgoing != nil {
+		outgoing.onRefresh = proxy.udpConnPool.Flush
+	}
+
 	// Configure HTTP proxy URL if specified
 	if len(config.HTTPProxyURL) > 0 {
 		httpProxyURL, err := url.Parse(config.HTTPProxyURL)

--- a/dnscrypt-proxy/dnsutils.go
+++ b/dnscrypt-proxy/dnsutils.go
@@ -512,7 +512,7 @@ func _dnsExchange(
 			proxy.prepareForRelay(udpAddr.IP, udpAddr.Port, &binQuery)
 			upstreamAddr = relay.RelayUDPAddr
 		}
-		pc, err := net.DialTimeout("udp", upstreamAddr.String(), proxy.timeout)
+		pc, err := proxy.xTransport.outgoing.dialTimeout("udp", upstreamAddr.String(), proxy.timeout)
 		if err != nil {
 			return DNSExchangeResponse{err: err}
 		}
@@ -558,7 +558,7 @@ func _dnsExchange(
 		var pc net.Conn
 		proxyDialer := proxy.xTransport.proxyDialer
 		if proxyDialer == nil {
-			pc, err = net.DialTimeout("tcp", upstreamAddr.String(), proxy.timeout)
+			pc, err = proxy.xTransport.outgoing.dialTimeout("tcp", upstreamAddr.String(), proxy.timeout)
 		} else {
 			pc, err = (*proxyDialer).Dial("tcp", upstreamAddr.String())
 		}

--- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
+++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
@@ -384,6 +384,14 @@ netprobe_timeout = 60
 
 netprobe_address = '9.9.9.9:53'
 
+## Source address for outgoing queries.
+## Accepts an interface name, or a literal IP address to pick a specific
+## address when an interface has several. Empty means the OS decides.
+## Forwarding rules, the network probe, connections through a proxy, and
+## queries to loopback destinations are all left unaffected.
+
+# outgoing_interface = 'eth0'
+
 
 ## Offline mode - Do not use any remote encrypted servers.
 ## The proxy will remain fully functional to respond to queries that

--- a/dnscrypt-proxy/outgoing.go
+++ b/dnscrypt-proxy/outgoing.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jedisct1/dlog"
+)
+
+type outgoingAddrs struct {
+	v4 net.IP
+	v6 net.IP
+}
+
+type outgoingSource struct {
+	iface      string
+	resolved   atomic.Pointer[outgoingAddrs]
+	refreshing atomic.Bool
+	refreshMu  sync.Mutex
+	onRefresh  func()
+}
+
+func newOutgoingSource(spec string) (*outgoingSource, error) {
+	if len(spec) == 0 {
+		return nil, nil
+	}
+	source := &outgoingSource{}
+	if ip := ParseIP(spec); ip != nil {
+		addrs := &outgoingAddrs{}
+		if ip4 := ip.To4(); ip4 != nil {
+			addrs.v4 = ip4
+		} else {
+			addrs.v6 = ip
+		}
+		source.resolved.Store(addrs)
+		return source, nil
+	}
+	source.iface = spec
+	if err := source.refresh(); err != nil {
+		return nil, err
+	}
+	return source, nil
+}
+
+func pickOutgoingAddrs(addrs []net.Addr) *outgoingAddrs {
+	picked := &outgoingAddrs{}
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP == nil || !ipNet.IP.IsGlobalUnicast() {
+			continue
+		}
+		if ip4 := ipNet.IP.To4(); ip4 != nil {
+			if picked.v4 == nil {
+				picked.v4 = ip4
+			}
+		} else if picked.v6 == nil {
+			picked.v6 = ipNet.IP
+		}
+	}
+	return picked
+}
+
+func (source *outgoingSource) refresh() error {
+	if source == nil || len(source.iface) == 0 {
+		return nil
+	}
+	iface, err := net.InterfaceByName(source.iface)
+	if err != nil {
+		return fmt.Errorf("Unknown outgoing interface [%s]: %v", source.iface, err)
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return fmt.Errorf("Unable to read the addresses of outgoing interface [%s]: %v", source.iface, err)
+	}
+	picked := pickOutgoingAddrs(addrs)
+	if picked.v4 == nil && picked.v6 == nil {
+		return fmt.Errorf("Outgoing interface [%s] has no usable address", source.iface)
+	}
+	source.resolved.Store(picked)
+	return nil
+}
+
+func (source *outgoingSource) localIP(dst net.IP) net.IP {
+	if source == nil {
+		return nil
+	}
+	resolved := source.resolved.Load()
+	if resolved == nil {
+		return nil
+	}
+	if dst == nil {
+		if resolved.v4 != nil {
+			return resolved.v4
+		}
+		return resolved.v6
+	}
+	if dst.To4() == nil {
+		return resolved.v6
+	}
+	return resolved.v4
+}
+
+var errNoOutgoingAddr = errors.New("No outgoing source address for the destination address family")
+
+func (source *outgoingSource) localIPFor(dst net.IP) (net.IP, error) {
+	if source == nil {
+		return nil, nil
+	}
+	if dst != nil && (dst.IsLoopback() || dst.IsUnspecified()) {
+		// Loopback and unspecified destinations never leave the host, so
+		// binding an interface source address to them accomplishes nothing
+		// and would only break the proxy's own self-directed queries.
+		return nil, nil
+	}
+	ip := source.localIP(dst)
+	if ip == nil {
+		return nil, errNoOutgoingAddr
+	}
+	return ip, nil
+}
+
+func (source *outgoingSource) udpLocalFor(dst net.IP) (*net.UDPAddr, error) {
+	ip, err := source.localIPFor(dst)
+	if ip == nil {
+		return nil, err
+	}
+	return &net.UDPAddr{IP: ip}, nil
+}
+
+func (source *outgoingSource) applyToErr(dialer *net.Dialer, network string, dst net.IP) error {
+	ip, err := source.localIPFor(dst)
+	if err != nil {
+		return err
+	}
+	if ip == nil {
+		return nil
+	}
+	// LocalAddr's concrete type must match network, or DialContext rejects it.
+	if strings.HasPrefix(network, "udp") {
+		dialer.LocalAddr = &net.UDPAddr{IP: ip}
+	} else {
+		dialer.LocalAddr = &net.TCPAddr{IP: ip}
+	}
+	return nil
+}
+
+func isBindError(err error) bool {
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) {
+		return false
+	}
+	var syscallErr *os.SyscallError
+	return errors.As(opErr.Err, &syscallErr) && syscallErr.Syscall == "bind"
+}
+
+func (source *outgoingSource) dialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: timeout}
+	if err := source.applyToErr(dialer, network, hostIP(address)); err != nil {
+		return nil, err
+	}
+	conn, err := dialer.DialContext(context.Background(), network, address)
+	source.noteDialError(err)
+	return conn, err
+}
+
+// refreshLocked serializes against a concurrent refresh so resolved.Store and
+// onRefresh from two refresh sources can't interleave.
+func (source *outgoingSource) refreshLocked() error {
+	source.refreshMu.Lock()
+	defer source.refreshMu.Unlock()
+	if err := source.refresh(); err != nil {
+		return err
+	}
+	if source.onRefresh != nil {
+		source.onRefresh()
+	}
+	return nil
+}
+
+func (source *outgoingSource) noteDialError(err error) {
+	if source == nil || len(source.iface) == 0 || err == nil || !isBindError(err) {
+		return
+	}
+	if !source.refreshing.CompareAndSwap(false, true) {
+		return
+	}
+	go func() {
+		defer source.refreshing.Store(false)
+		if err := source.refreshLocked(); err != nil {
+			dlog.Debugf("Unable to refresh outgoing interface [%s]: %v", source.iface, err)
+		}
+	}()
+}
+
+func hostIP(address string) net.IP {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil
+	}
+	return ParseIP(host)
+}

--- a/dnscrypt-proxy/outgoing_test.go
+++ b/dnscrypt-proxy/outgoing_test.go
@@ -1,0 +1,528 @@
+package main
+
+import (
+	"errors"
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestNewOutgoingSourceEmpty(t *testing.T) {
+	source, err := newOutgoingSource("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if source != nil {
+		t.Fatal("expected a nil source when unconfigured")
+	}
+	if source.localIP(net.ParseIP("192.0.2.1")) != nil {
+		t.Fatal("expected a nil local address from a nil source")
+	}
+}
+
+func TestNewOutgoingSourceLiteralV4(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := source.localIP(net.ParseIP("198.51.100.1")); !got.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected 192.0.2.10, got %v", got)
+	}
+	if got := source.localIP(net.ParseIP("2001:db8::1")); got != nil {
+		t.Fatalf("expected no IPv6 source, got %v", got)
+	}
+}
+
+func TestNewOutgoingSourceLiteralV6(t *testing.T) {
+	source, err := newOutgoingSource("2001:db8::10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := source.localIP(net.ParseIP("2001:db8::1")); !got.Equal(net.ParseIP("2001:db8::10")) {
+		t.Fatalf("expected 2001:db8::10, got %v", got)
+	}
+	if got := source.localIP(net.ParseIP("198.51.100.1")); got != nil {
+		t.Fatalf("expected no IPv4 source, got %v", got)
+	}
+}
+
+func TestLocalIPUnknownDestinationFamily(t *testing.T) {
+	v4Source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := v4Source.localIP(nil); !got.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected 192.0.2.10, got %v", got)
+	}
+
+	v6Source, err := newOutgoingSource("2001:db8::10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := v6Source.localIP(nil); !got.Equal(net.ParseIP("2001:db8::10")) {
+		t.Fatalf("expected 2001:db8::10, got %v", got)
+	}
+
+	both, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	both.resolved.Store(&outgoingAddrs{v4: net.ParseIP("192.0.2.10").To4(), v6: net.ParseIP("2001:db8::10")})
+	if got := both.localIP(nil); !got.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected IPv4 to win for an unknown destination family, got %v", got)
+	}
+}
+
+func TestNewOutgoingSourceUnknownInterface(t *testing.T) {
+	if _, err := newOutgoingSource("zzz-no-such-interface"); err == nil {
+		t.Fatal("expected an error for an unknown interface")
+	}
+}
+
+func TestPickOutgoingAddrs(t *testing.T) {
+	_, linkLocal, _ := net.ParseCIDR("fe80::1/64")
+	linkLocal.IP = net.ParseIP("fe80::1")
+	_, loopback, _ := net.ParseCIDR("127.0.0.1/8")
+	loopback.IP = net.ParseIP("127.0.0.1")
+	_, v4, _ := net.ParseCIDR("192.0.2.10/24")
+	v4.IP = net.ParseIP("192.0.2.10")
+	_, v4Second, _ := net.ParseCIDR("192.0.2.11/24")
+	v4Second.IP = net.ParseIP("192.0.2.11")
+	_, v6, _ := net.ParseCIDR("2001:db8::10/64")
+	v6.IP = net.ParseIP("2001:db8::10")
+
+	picked := pickOutgoingAddrs([]net.Addr{loopback, linkLocal, v4, v4Second, v6})
+	if !picked.v4.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected the first global unicast IPv4, got %v", picked.v4)
+	}
+	if !picked.v6.Equal(net.ParseIP("2001:db8::10")) {
+		t.Fatalf("expected the global unicast IPv6, got %v", picked.v6)
+	}
+}
+
+func TestPickOutgoingAddrsNoUsableAddress(t *testing.T) {
+	_, loopback, _ := net.ParseCIDR("127.0.0.1/8")
+	loopback.IP = net.ParseIP("127.0.0.1")
+	picked := pickOutgoingAddrs([]net.Addr{loopback})
+	if picked.v4 != nil || picked.v6 != nil {
+		t.Fatal("expected no usable address")
+	}
+}
+
+func TestIsBindError(t *testing.T) {
+	bindErr := &net.OpError{Op: "dial", Err: os.NewSyscallError("bind", errors.New("cannot assign requested address"))}
+	if !isBindError(bindErr) {
+		t.Fatal("expected a bind error to be recognised")
+	}
+	connectErr := &net.OpError{Op: "dial", Err: os.NewSyscallError("connect", errors.New("connection refused"))}
+	if isBindError(connectErr) {
+		t.Fatal("expected a connect error not to be recognised")
+	}
+	if isBindError(errors.New("unrelated")) {
+		t.Fatal("expected an unrelated error not to be recognised")
+	}
+}
+
+func TestUDPConnPoolFlushClosesConns(t *testing.T) {
+	pool := NewUDPConnPool()
+	defer pool.Close()
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:53")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	conn, err := pool.Get(addr, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pool.Put(addr, conn)
+	if total, _ := pool.Stats(); total != 1 {
+		t.Fatalf("expected 1 pooled connection, got %d", total)
+	}
+	pool.Flush()
+	if total, addrCount := pool.Stats(); total != 0 || addrCount != 0 {
+		t.Fatalf("expected an empty pool after Flush, got %d conns across %d addrs", total, addrCount)
+	}
+	if _, err := conn.Write([]byte{0}); err == nil {
+		t.Fatal("expected the pooled connection to be closed by Flush")
+	}
+}
+
+func TestUdpLocalForUnsetSourceIsNotAnError(t *testing.T) {
+	var source *outgoingSource
+	laddr, err := source.udpLocalFor(net.ParseIP("2001:db8::1"))
+	if err != nil {
+		t.Fatalf("an unset source must never fail: %v", err)
+	}
+	if laddr != nil {
+		t.Fatalf("expected no local address, got %v", laddr)
+	}
+}
+
+func TestUdpLocalForMissingFamilyFails(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := source.udpLocalFor(net.ParseIP("2001:db8::1")); !errors.Is(err, errNoOutgoingAddr) {
+		t.Fatalf("expected errNoOutgoingAddr, got %v", err)
+	}
+	laddr, err := source.udpLocalFor(net.ParseIP("198.51.100.1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !laddr.IP.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected 192.0.2.10, got %v", laddr)
+	}
+}
+
+func TestLoopbackDestinationIsNeverBoundV4(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	laddr, err := source.udpLocalFor(net.ParseIP("127.0.0.1"))
+	if err != nil {
+		t.Fatalf("a loopback destination must never fail: %v", err)
+	}
+	if laddr != nil {
+		t.Fatalf("expected no local address for a loopback destination, got %v", laddr)
+	}
+}
+
+func TestLoopbackDestinationIsNeverBoundV6(t *testing.T) {
+	source, err := newOutgoingSource("2001:db8::10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	laddr, err := source.udpLocalFor(net.ParseIP("::1"))
+	if err != nil {
+		t.Fatalf("a loopback destination must never fail: %v", err)
+	}
+	if laddr != nil {
+		t.Fatalf("expected no local address for a loopback destination, got %v", laddr)
+	}
+}
+
+func TestLoopbackDestinationSkipsMissingFamilyError(t *testing.T) {
+	// A v4-only source would normally fail closed for an IPv6 destination;
+	// loopback destinations must bypass that check entirely.
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := source.udpLocalFor(net.ParseIP("::1")); err != nil {
+		t.Fatalf("a loopback destination must never fail: %v", err)
+	}
+
+	v6Source, err := newOutgoingSource("2001:db8::10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := v6Source.udpLocalFor(net.ParseIP("127.0.0.1")); err != nil {
+		t.Fatalf("a loopback destination must never fail: %v", err)
+	}
+}
+
+func TestUnspecifiedDestinationIsNeverBoundV4(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	laddr, err := source.udpLocalFor(net.ParseIP("0.0.0.0"))
+	if err != nil {
+		t.Fatalf("an unspecified destination must never fail: %v", err)
+	}
+	if laddr != nil {
+		t.Fatalf("expected no local address for an unspecified destination, got %v", laddr)
+	}
+}
+
+func TestUnspecifiedDestinationIsNeverBoundV6(t *testing.T) {
+	source, err := newOutgoingSource("2001:db8::10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	laddr, err := source.udpLocalFor(net.ParseIP("::"))
+	if err != nil {
+		t.Fatalf("an unspecified destination must never fail: %v", err)
+	}
+	if laddr != nil {
+		t.Fatalf("expected no local address for an unspecified destination, got %v", laddr)
+	}
+}
+
+func TestUnspecifiedDestinationSkipsMissingFamilyError(t *testing.T) {
+	// A v4-only source would normally fail closed for an IPv6 destination;
+	// unspecified destinations must bypass that check entirely.
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := source.udpLocalFor(net.ParseIP("::")); err != nil {
+		t.Fatalf("an unspecified destination must never fail: %v", err)
+	}
+
+	v6Source, err := newOutgoingSource("2001:db8::10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := v6Source.udpLocalFor(net.ParseIP("0.0.0.0")); err != nil {
+		t.Fatalf("an unspecified destination must never fail: %v", err)
+	}
+}
+
+func TestApplyToErrMissingFamilyFails(t *testing.T) {
+	source, err := newOutgoingSource("2001:db8::10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dialer := &net.Dialer{}
+	if err := source.applyToErr(dialer, "tcp", net.ParseIP("198.51.100.1")); !errors.Is(err, errNoOutgoingAddr) {
+		t.Fatalf("expected errNoOutgoingAddr, got %v", err)
+	}
+	if dialer.LocalAddr != nil {
+		t.Fatal("expected LocalAddr to stay unset when the family is missing")
+	}
+}
+
+func TestApplyToErrUnknownDestinationFamilyIsNotAnError(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dialer := &net.Dialer{}
+	if err := source.applyToErr(dialer, "tcp", nil); err != nil {
+		t.Fatalf("an unknown destination family must not fail: %v", err)
+	}
+	if dialer.LocalAddr == nil {
+		t.Fatal("expected the v4 source to be applied for an unknown destination family")
+	}
+}
+
+func TestApplyToErrNilSourceIsNotAnError(t *testing.T) {
+	var source *outgoingSource
+	dialer := &net.Dialer{}
+	if err := source.applyToErr(dialer, "udp", net.ParseIP("198.51.100.1")); err != nil {
+		t.Fatalf("a nil source must never fail: %v", err)
+	}
+	if dialer.LocalAddr != nil {
+		t.Fatal("expected LocalAddr to stay nil for a nil source")
+	}
+}
+
+func TestApplyToErrSetsUDPAddrForUDPNetwork(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dialer := &net.Dialer{}
+	if err := source.applyToErr(dialer, "udp", net.ParseIP("198.51.100.1")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	udpAddr, ok := dialer.LocalAddr.(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("expected a *net.UDPAddr LocalAddr for a udp network, got %T", dialer.LocalAddr)
+	}
+	if !udpAddr.IP.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected 192.0.2.10, got %v", udpAddr.IP)
+	}
+}
+
+func TestApplyToErrSetsTCPAddrForTCPNetwork(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	dialer := &net.Dialer{}
+	if err := source.applyToErr(dialer, "tcp", net.ParseIP("198.51.100.1")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	tcpAddr, ok := dialer.LocalAddr.(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("expected a *net.TCPAddr LocalAddr for a tcp network, got %T", dialer.LocalAddr)
+	}
+	if !tcpAddr.IP.Equal(net.ParseIP("192.0.2.10")) {
+		t.Fatalf("expected 192.0.2.10, got %v", tcpAddr.IP)
+	}
+}
+
+func twoDistinctNonLoopbackIPv4s(t *testing.T) (dest, src net.IP) {
+	t.Helper()
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Skipf("cannot enumerate addresses: %v", err)
+	}
+	var found []net.IP
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP == nil || !ipNet.IP.IsGlobalUnicast() {
+			continue
+		}
+		if ip4 := ipNet.IP.To4(); ip4 != nil {
+			found = append(found, ip4)
+		}
+	}
+	if len(found) < 2 {
+		t.Skip("need two distinct non-loopback IPv4 addresses on the host to exercise a real bind")
+	}
+	return found[0], found[1]
+}
+
+func TestDialTimeoutUDPWithConfiguredSourceSucceeds(t *testing.T) {
+	// dest and src must differ: dialing a destination that happens to equal
+	// the local address makes the kernel pick that address as the source
+	// via the local routing table even without an explicit bind, which
+	// would make this test pass whether or not dialTimeout actually binds.
+	dest, src := twoDistinctNonLoopbackIPv4s(t)
+
+	source, err := newOutgoingSource(src.String())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	listener, err := net.ListenUDP("udp", &net.UDPAddr{IP: dest})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer listener.Close()
+	conn, err := source.dialTimeout("udp", listener.LocalAddr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("expected a udp dial with a configured source to succeed, got: %v", err)
+	}
+	defer conn.Close()
+	udpAddr, ok := conn.LocalAddr().(*net.UDPAddr)
+	if !ok {
+		t.Fatalf("expected a *net.UDPAddr local address, got %T", conn.LocalAddr())
+	}
+	if !udpAddr.IP.Equal(src) {
+		t.Fatalf("expected the dial to bind the configured source %v, got %v", src, udpAddr.IP)
+	}
+}
+
+func TestDialTimeoutNilSourceDialsBothProtocols(t *testing.T) {
+	var source *outgoingSource
+
+	udpListener, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer udpListener.Close()
+	udpConn, err := source.dialTimeout("udp", udpListener.LocalAddr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("expected a udp dial with a nil source to succeed, got: %v", err)
+	}
+	udpConn.Close()
+
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer tcpListener.Close()
+	tcpConn, err := source.dialTimeout("tcp", tcpListener.Addr().String(), time.Second)
+	if err != nil {
+		t.Fatalf("expected a tcp dial with a nil source to succeed, got: %v", err)
+	}
+	tcpConn.Close()
+}
+
+func TestHostIP(t *testing.T) {
+	cases := []struct {
+		name    string
+		address string
+		want    net.IP
+	}{
+		{"ipv4 with port", "1.2.3.4:53", net.ParseIP("1.2.3.4")},
+		{"ipv6 with port", "[2001:db8::1]:53", net.ParseIP("2001:db8::1")},
+		{"hostname with port", "example.com:443", nil},
+		{"ipv6 with zone", "[fe80::1%eth0]:53", nil},
+		{"no port", "1.2.3.4", nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := hostIP(c.address)
+			if c.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %v", got)
+				}
+				return
+			}
+			if !got.Equal(c.want) {
+				t.Fatalf("expected %v, got %v", c.want, got)
+			}
+		})
+	}
+}
+
+func TestRefreshLockedWaitsForInProgressRefresh(t *testing.T) {
+	source, err := newOutgoingSource("192.0.2.10")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		source.refreshMu.Lock()
+		close(locked)
+		<-release
+		source.refreshMu.Unlock()
+	}()
+	<-locked
+
+	done := make(chan error, 1)
+	go func() { done <- source.refreshLocked() }()
+
+	select {
+	case <-done:
+		t.Fatal("expected refreshLocked to wait for the in-progress refresh instead of dropping it")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func firstUsableInterfaceName(t *testing.T) string {
+	t.Helper()
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Skipf("cannot enumerate interfaces: %v", err)
+	}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		if picked := pickOutgoingAddrs(addrs); picked.v4 != nil || picked.v6 != nil {
+			return iface.Name
+		}
+	}
+	t.Skip("no interface with a usable address found")
+	return ""
+}
+
+func TestNoteDialErrorReleasesFlagAfterSuccess(t *testing.T) {
+	source, err := newOutgoingSource(firstUsableInterfaceName(t))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	called := make(chan struct{}, 1)
+	source.onRefresh = func() { called <- struct{}{} }
+	bindErr := &net.OpError{Op: "dial", Err: os.NewSyscallError("bind", errors.New("cannot assign requested address"))}
+
+	source.noteDialError(bindErr)
+	select {
+	case <-called:
+	case <-time.After(time.Second):
+		t.Fatal("expected onRefresh to fire after the bind-error refresh")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for source.refreshing.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("expected the refreshing flag to be released after a successful refresh, future refreshes would be silently disabled otherwise")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/dnscrypt-proxy/plugin_dns64.go
+++ b/dnscrypt-proxy/plugin_dns64.go
@@ -200,10 +200,18 @@ func translateToIPv6(ipv4 net.IP, prefix *net.IPNet) net.IP {
 func (plugin *PluginDNS64) fetchPref64(resolver string) error {
 	msg := dns.NewMsg(rfc7050WKN, dns.TypeAAAA)
 
-	client := new(dns.Client)
+	transport := dns.NewTransport()
+	// See resolveUsingResolver: NewTransport() aliases the global Dialer.
+	localDialer := *transport.Dialer
+	transport.Dialer = &localDialer
+	if err := plugin.proxy.xTransport.outgoing.applyToErr(transport.Dialer, "udp", hostIP(resolver)); err != nil {
+		return err
+	}
+	client := dns.Client{Transport: transport}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	resp, _, err := client.Exchange(ctx, msg, "udp", resolver)
+	plugin.proxy.xTransport.outgoing.noteDialError(err)
 	if err != nil {
 		return err
 	}

--- a/dnscrypt-proxy/proxy.go
+++ b/dnscrypt-proxy/proxy.go
@@ -134,6 +134,11 @@ func (proxy *Proxy) registerLocalDoHListener(listener *net.TCPListener) {
 }
 
 func (proxy *Proxy) handleNetworkChange() {
+	if outgoing := proxy.xTransport.outgoing; outgoing != nil {
+		if err := outgoing.refreshLocked(); err != nil {
+			dlog.Warnf("Unable to refresh the outgoing source address: %v", err)
+		}
+	}
 	if proxy.ephemeralKeys {
 		return
 	}
@@ -617,7 +622,12 @@ func (proxy *Proxy) exchangeWithUDPServer(
 		return proxy.exchangeWithUDPServerViaProxy(serverInfo, sharedKey, encryptedQuery, clientNonce, queryEpoch, upstreamAddr, proxyDialer)
 	}
 
-	pc, err := proxy.udpConnPool.Get(upstreamAddr)
+	laddr, err := proxy.xTransport.outgoing.udpLocalFor(upstreamAddr.IP)
+	if err != nil {
+		return nil, err
+	}
+	pc, err := proxy.udpConnPool.Get(upstreamAddr, laddr)
+	proxy.xTransport.outgoing.noteDialError(err)
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +726,7 @@ func (proxy *Proxy) exchangeWithTCPServer(
 	var pc net.Conn
 	proxyDialer := proxy.xTransport.proxyDialer
 	if proxyDialer == nil {
-		pc, err = net.DialTimeout("tcp", upstreamAddr.String(), serverInfo.Timeout)
+		pc, err = proxy.xTransport.outgoing.dialTimeout("tcp", upstreamAddr.String(), serverInfo.Timeout)
 	} else {
 		pc, err = (*proxyDialer).Dial("tcp", upstreamAddr.String())
 	}

--- a/dnscrypt-proxy/udp_conn_pool.go
+++ b/dnscrypt-proxy/udp_conn_pool.go
@@ -91,7 +91,7 @@ func (p *UDPConnPool) cleanupStale() {
 	}
 }
 
-func (p *UDPConnPool) Get(addr *net.UDPAddr) (*net.UDPConn, error) {
+func (p *UDPConnPool) Get(addr *net.UDPAddr, laddr *net.UDPAddr) (*net.UDPConn, error) {
 	addrStr := addr.String()
 	shard := p.getShard(addrStr)
 
@@ -107,7 +107,7 @@ func (p *UDPConnPool) Get(addr *net.UDPAddr) (*net.UDPConn, error) {
 	}
 	shard.Unlock()
 
-	return net.DialUDP("udp", nil, addr)
+	return net.DialUDP("udp", laddr, addr)
 }
 
 func (p *UDPConnPool) Put(addr *net.UDPAddr, conn *net.UDPConn) {
@@ -152,7 +152,11 @@ func (p *UDPConnPool) Close() {
 		close(p.stopCh)
 	})
 	atomic.StoreInt32(&p.closed, 1)
+	p.Flush()
+	dlog.Debug("UDP connection pool closed")
+}
 
+func (p *UDPConnPool) Flush() {
 	for i := range p.shards {
 		shard := &p.shards[i]
 		shard.Lock()
@@ -164,7 +168,6 @@ func (p *UDPConnPool) Close() {
 		}
 		shard.Unlock()
 	}
-	dlog.Debug("UDP connection pool closed")
 }
 
 func (p *UDPConnPool) Stats() (totalConns int, addrCount int) {

--- a/dnscrypt-proxy/udp_conn_pool_test.go
+++ b/dnscrypt-proxy/udp_conn_pool_test.go
@@ -17,7 +17,7 @@ func TestUDPConnPool_Basic(t *testing.T) {
 		t.Fatalf("Failed to resolve address: %v", err)
 	}
 
-	conn, err := pool.Get(addr)
+	conn, err := pool.Get(addr, nil)
 	if err != nil {
 		t.Fatalf("Failed to get connection: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestUDPConnPool_Basic(t *testing.T) {
 
 	pool.Put(addr, conn)
 
-	conn2, err := pool.Get(addr)
+	conn2, err := pool.Get(addr, nil)
 	if err != nil {
 		t.Fatalf("Failed to get connection second time: %v", err)
 	}
@@ -54,7 +54,7 @@ func TestUDPConnPool_MaxConns(t *testing.T) {
 
 	var conns []*net.UDPConn
 	for i := range UDPPoolMaxConnsPerAddr + 2 {
-		conn, err := pool.Get(addr)
+		conn, err := pool.Get(addr, nil)
 		if err != nil {
 			t.Fatalf("Failed to get connection %d: %v", i, err)
 		}
@@ -77,7 +77,7 @@ func TestUDPConnPool_Discard(t *testing.T) {
 
 	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:53")
 
-	conn, err := pool.Get(addr)
+	conn, err := pool.Get(addr, nil)
 	if err != nil {
 		t.Fatalf("Failed to get connection: %v", err)
 	}
@@ -102,7 +102,7 @@ func TestUDPConnPool_Concurrent(t *testing.T) {
 	for range 10 {
 		wg.Go(func() {
 			for range iterations {
-				conn, err := pool.Get(addr)
+				conn, err := pool.Get(addr, nil)
 				if err != nil {
 					t.Errorf("Failed to get connection: %v", err)
 					return
@@ -128,8 +128,8 @@ func TestUDPConnPool_MultipleAddresses(t *testing.T) {
 	addr1, _ := net.ResolveUDPAddr("udp", "127.0.0.1:53")
 	addr2, _ := net.ResolveUDPAddr("udp", "127.0.0.1:5353")
 
-	conn1, _ := pool.Get(addr1)
-	conn2, _ := pool.Get(addr2)
+	conn1, _ := pool.Get(addr1, nil)
+	conn2, _ := pool.Get(addr2, nil)
 
 	pool.Put(addr1, conn1)
 	pool.Put(addr2, conn2)
@@ -148,12 +148,12 @@ func TestUDPConnPool_Close(t *testing.T) {
 
 	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:53")
 
-	conn, _ := pool.Get(addr)
+	conn, _ := pool.Get(addr, nil)
 	pool.Put(addr, conn)
 
 	pool.Close()
 
-	conn2, err := pool.Get(addr)
+	conn2, err := pool.Get(addr, nil)
 	if err != nil {
 		t.Fatalf("Get after close should still work: %v", err)
 	}
@@ -172,12 +172,12 @@ func BenchmarkUDPConnPool_GetPut(b *testing.B) {
 
 	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:53")
 
-	conn, _ := pool.Get(addr)
+	conn, _ := pool.Get(addr, nil)
 	pool.Put(addr, conn)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		conn, _ := pool.Get(addr)
+		conn, _ := pool.Get(addr, nil)
 		pool.Put(addr, conn)
 	}
 }
@@ -198,13 +198,13 @@ func BenchmarkUDPConnPool_Contention(b *testing.B) {
 
 	addr, _ := net.ResolveUDPAddr("udp", "127.0.0.1:53")
 
-	conn, _ := pool.Get(addr)
+	conn, _ := pool.Get(addr, nil)
 	pool.Put(addr, conn)
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			conn, _ := pool.Get(addr)
+			conn, _ := pool.Get(addr, nil)
 			pool.Put(addr, conn)
 		}
 	})
@@ -217,7 +217,7 @@ func BenchmarkUDPConnPool_MultiAddrContention(b *testing.B) {
 	addrs := make([]*net.UDPAddr, 16)
 	for i := range addrs {
 		addrs[i], _ = net.ResolveUDPAddr("udp", fmt.Sprintf("127.0.0.1:%d", 5300+i))
-		conn, _ := pool.Get(addrs[i])
+		conn, _ := pool.Get(addrs[i], nil)
 		pool.Put(addrs[i], conn)
 	}
 
@@ -226,7 +226,7 @@ func BenchmarkUDPConnPool_MultiAddrContention(b *testing.B) {
 		i := 0
 		for pb.Next() {
 			addr := addrs[i%len(addrs)]
-			conn, _ := pool.Get(addr)
+			conn, _ := pool.Get(addr, nil)
 			pool.Put(addr, conn)
 			i++
 		}

--- a/dnscrypt-proxy/xtransport.go
+++ b/dnscrypt-proxy/xtransport.go
@@ -98,6 +98,7 @@ type XTransport struct {
 	tlsDisableSessionTickets bool
 	tlsPreferRSA             bool
 	proxyDialer              *netproxy.Dialer
+	outgoing                 *outgoingSource
 	httpProxyFunction        func(*http.Request) (*url.URL, error)
 	tlsClientCreds           DOHClientCreds
 	keyLogWriter             io.Writer
@@ -324,7 +325,12 @@ func (xTransport *XTransport) rebuildTransport() {
 			dial := func(address string) (net.Conn, error) {
 				if xTransport.proxyDialer == nil {
 					dialer := &net.Dialer{Timeout: timeout, KeepAlive: xTransport.keepAlive, DualStack: true}
-					return dialer.DialContext(ctx, network, address)
+					if err := xTransport.outgoing.applyToErr(dialer, network, hostIP(address)); err != nil {
+						return nil, err
+					}
+					conn, err := dialer.DialContext(ctx, network, address)
+					xTransport.outgoing.noteDialError(err)
+					return conn, err
 				}
 				return (*xTransport.proxyDialer).Dial(network, address)
 			}
@@ -479,7 +485,16 @@ func (xTransport *XTransport) rebuildTransport() {
 					}
 					continue
 				}
-				udpConn, err := net.ListenUDP(target.network, nil)
+				laddr, err := xTransport.outgoing.udpLocalFor(udpAddr.IP)
+				if err != nil {
+					lastErr = err
+					if idx < len(targets)-1 {
+						dlog.Debugf("H3: no outgoing source address for [%s] on %s: %v", target.addr, target.network, err)
+					}
+					continue
+				}
+				udpConn, err := net.ListenUDP(target.network, laddr)
+				xTransport.outgoing.noteDialError(err)
 				if err != nil {
 					lastErr = err
 					if idx < len(targets)-1 {
@@ -529,7 +544,15 @@ func (xTransport *XTransport) resolveUsingResolver(
 	returnIPv4, returnIPv6 bool,
 ) (ips []net.IP, ttl time.Duration, err error) {
 	transport := dns.NewTransport()
+	// dns.NewTransport() aliases the package-global default Dialer. Replace it
+	// before binding, or applyToErr below would bind every dns.Client in the
+	// process, including plugin_forward.go's.
+	localDialer := *transport.Dialer
+	transport.Dialer = &localDialer
 	transport.ReadTimeout = ResolverReadTimeout
+	if err = xTransport.outgoing.applyToErr(transport.Dialer, proto, hostIP(resolver)); err != nil {
+		return nil, 0, err
+	}
 	dnsClient := dns.Client{Transport: transport}
 	queryType := make([]uint16, 0, 2)
 	if returnIPv4 {
@@ -570,6 +593,7 @@ func (xTransport *XTransport) resolveUsingResolver(
 		} else {
 			lastErr = err
 		}
+		xTransport.outgoing.noteDialError(err)
 	}
 	if len(ips) > 0 {
 		ttl = time.Duration(rrTTL) * time.Second


### PR DESCRIPTION
On a firewall the OS routes by destination, not source. Multi-WAN and VPN policy routing works by matching a known source address and sending it to a chosen gateway. dnscrypt-proxy currently lets the OS pick the source for every outgoing query, so its traffic cannot be selected by such a rule and always follows the default route.

This adds an `outgoing_interface` option to bind that source. Empty by default, so nothing changes for existing installations.

Requested in #1437 (closed without implementation) and #3248.

## Configuration

```toml
## Source address for outgoing queries.
## Accepts an interface name, or a literal IP address to pick a specific
## address when an interface has several. Empty means the OS decides.
## Forwarding rules, the network probe, connections through a proxy, and
## queries to loopback destinations are all left unaffected.

# outgoing_interface = 'eth0'
```

The value is parsed as an IP first; if that fails it is treated as an interface name. No interface name parses as an IP, so there is no ambiguity.

An interface name resolves to its current addresses and is re-resolved on network change, which is what makes a DHCP lease renewal survivable. The literal form exists for selecting one address when an interface carries several, such as a CARP VIP.

I went with resolving to an address rather than `SO_BINDTODEVICE` because FreeBSD has no equivalent (`IP_SENDIF` was proposed in 2004 and never landed), and because policy routing rules match on source IP anyway, so the address is what the use case actually needs. A second Linux-only mechanism would fork the behaviour per platform for no gain.

## Scope

Bound: DNSCrypt UDP and TCP, certificate probes, bootstrap resolution, the cloaking and DNS64 name lookups, DoH and ODoH, DoH3.

Not bound, deliberately:

- `forwarding_rules`, which commonly target LAN or localhost resolvers a WAN source would make unreachable.
- The network probe, which is a pre-startup connectivity check.
- Loopback and unspecified destinations, at every site. That traffic is host-local and never traverses an interface, so binding it achieves nothing while breaking the proxy's own internal resolution, which uses `listen_addresses` as its resolver list.
- Anything going through `proxy`, where a local bind has no meaning. Setting both warns at startup.

A configured source with no address of the destination's family fails the query rather than dialling unbound, so a misconfiguration cannot silently leak to the default gateway.

## Notes

Two things that are easy to get wrong and are worth a second look during review:

- `net.Dialer.LocalAddr` is an interface field, so the concrete type has to match the network. A `*net.TCPAddr` on a `udp` network is rejected with `mismatched local address type`.
- `dns.NewTransport()` returns a struct copy whose `Dialer` field aliases a package global, so it has to be replaced before binding or every `dns.Client` in the process is affected, including the forwarding plugin's.

## Verification

Unit tests cover the resolution, family selection and fail-closed logic. No unit test can prove a packet left with the intended source, so I also built a container harness that runs the real binary against two networks and asserts the source address observed by the upstream. It covers the option unset, the interface-name and literal forms, the DNSCrypt path through the connection pool, an invalid interface name, the fail-closed case, and the loopback exclusion.

Each of those checks was confirmed to fail when the corresponding logic is reverted, rather than only confirmed to pass. I can share the harness separately if desired; I left it out here to keep the diff to the feature.

### On pfSense

Also verified on pfSense 2.8.1-RELEASE (FreeBSD 15.0-CURRENT, amd64), since the FreeBSD reasoning above is the whole basis for the design. The proxy and the test binary were cross-compiled with `CGO_ENABLED=0 GOOS=freebsd GOARCH=amd64` and run on the firewall as a second instance on a spare loopback port, so nothing serving real DNS was touched.

- The unit suite runs natively: 27 tests, all passing, none skipped.
- `outgoing_interface = 'ix1.5'` moved the observed source from `10.0.0.1` to `10.0.2.1`, so interface-name resolution works, VLAN names included.
- The literal form selected a secondary address on an interface carrying two, which is the CARP VIP case.
- `outgoing_interface = 'zzz0'` aborted at startup with `Unknown outgoing interface [zzz0]: route ip+net: no such network interface`.
- The bound source reached the wire unrewritten on the WAN interface. Whether it survives at all depends on the outbound NAT rules in play, which is the caveat below rather than a property of the option.

This option sets the source address and nothing else. It does not select a route or a gateway. On a firewall it makes DNS traffic distinguishable so that policy routing can act on it, which is the point, but the routing itself remains the operator's job. Outbound NAT can also rewrite a bound source before it leaves the box, so a matching NAT exemption may be needed for the binding to be observable.
